### PR TITLE
Scope naming for kt_jvm intermediate targets

### DIFF
--- a/internal/scope_name.bzl
+++ b/internal/scope_name.bzl
@@ -2,5 +2,4 @@ def scope_name(name, suffix):
     if name == native.package_name().split("/")[-1]:
         return suffix
 
-    return "%s-%s" % (name, suffix)
-    
+    return "{}-{}".format(name, suffix)

--- a/internal/scope_name.bzl
+++ b/internal/scope_name.bzl
@@ -1,0 +1,6 @@
+def scope_name(name, suffix):
+    if name == native.package_name().split("/")[-1]:
+        return suffix
+
+    return "%s-%s" % (name, suffix)
+    

--- a/kotlin/build.bzl
+++ b/kotlin/build.bzl
@@ -1,5 +1,6 @@
 load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 load("@junit//junit5-jupiter-starter-bazel:junit5.bzl", "kt_jvm_junit5_test")
+load("//internal:scope_name.bzl", "scope_name")
 
 # No project specific defaults here
 def kt_jvm_library_and_test(
@@ -60,7 +61,7 @@ def kt_jvm_library_and_test(
 
     if len(test_srcs) != 0:
         kt_jvm_junit5_test(
-            name = "%s-test" % name,
+            name = scope_name(name, "test"),
             srcs = test_srcs,
             resources = test_resources,
             resource_jars = test_resource_jars,

--- a/kotlin/distribution.bzl
+++ b/kotlin/distribution.bzl
@@ -1,4 +1,5 @@
 load("@vaticle_bazel_distribution//maven:rules.bzl", "assemble_maven", "deploy_maven")
+load("//internal:scope_name.bzl", "scope_name")
 
 def distribution(
         *,
@@ -16,7 +17,7 @@ def distribution(
 
         workspace_refs = None,
 ):
-    assemble_name = "%s-assemble" % name
+    assemble_name = scope_name(name, "assemble")
     assemble_maven(
         name = assemble_name,
         target = ":%s" % name,
@@ -29,7 +30,7 @@ def distribution(
     )
 
     deploy_maven(
-        name = "%s-deploy" % name,
+        name = scope_name(name, "deploy"),
         target = ":%s" % assemble_name,
         release = release_repo,
         snapshot = snapshot_repo,

--- a/kotlin/lint.bzl
+++ b/kotlin/lint.bzl
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_kotlin//kotlin:lint.bzl", "ktlint_fix", "ktlint_test")
+load("//internal:scope_name.bzl", "scope_name")
 
 def lint(
         *,
@@ -8,13 +9,13 @@ def lint(
         lint_config,
 ):
     ktlint_test(
-        name = "%s-lint" % name,
+        name = scope_name(name, "lint"),
         srcs = srcs,
         config = lint_config,
     )
 
     ktlint_fix(
-        name = "%s-lint-fix" % name,
+        name = scope_name(name, "lint-fix"),
         srcs = srcs,
         config = lint_config,
     )


### PR DESCRIPTION
# Release Notes

If the target name is the same as the local package name, the generated targets will omit the names. 

### Regular scope naming strategy:
```python
# path/to/module-a/BUILD
kt_jvm(name = "module-a-sub-lib")
```

Generates linting targets against `module-a-sub-lib`:
```
//path/to/module-a:module-a-sub-lib-lint
//path/to/module-a:module-a-sub-lib-lint-fix
```

### Optimized scope naming strategy:
```python
# path/to/module-a/BUILD
kt_jvm(name = "module-a")
```

Generates linting targets against `module-a-sub-lib`:
```
//path/to/module-a:lint
//path/to/module-a:lint-fix
```