### PR TITLE
Add rule for publishing to org-level github-pages repo

### DIFF
--- a/gh-pages/BUILD
+++ b/gh-pages/BUILD
@@ -1,0 +1,9 @@
+load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+nodejs_binary(
+    name = "gh_pages_deploy",
+    data = [],
+    entry_point = ":gh-pages.js",
+)

--- a/gh-pages/README.md
+++ b/gh-pages/README.md
@@ -1,0 +1,38 @@
+# GH Pages Deployment
+
+The rules defined here outline a basic pipeline of deploying a folder to an org-level github-pages repo.
+It leverages the same `VERSION` file that many of our distribution rules use, and automatically publishes docs to sub-folders based on their release versions
+
+The repo structure would look something like:
+
+```
+<org>.github.io/
+  1/
+  2/
+  latest/
+  next/
+```
+
+where numbered folders correspond to the major version of the release, `latest` is an alias for the last main version, and `next` corresponds to the latest canary release.
+
+You must supply a `GH_TOKEN` environment variable that has push rights to the target repo.
+
+
+To use the rule, define it in your docs folder with the data to be published: 
+
+```python
+load("@rules_player//gh-pages:index.bzl", "gh_pages")
+
+gh_pages(
+  name="deploy_docs",
+  source_dir=package_name() + "/src",
+  repo="<example-org>/<example-org>.github.io",
+  data = glob(["src/**"])
+)
+```
+
+and run it during your deployment:
+
+```sh
+bazel run //packages/docs:deploy_docs
+```

--- a/gh-pages/gh-pages.js
+++ b/gh-pages/gh-pages.js
@@ -1,0 +1,61 @@
+const fse = require('fs-extra');
+const ghPages = require('gh-pages');
+const { execSync } = require('child_process');
+
+async function deployPages(dir, config) {
+  return new Promise((resolve, reject) => { 
+    ghPages.publish(dir, config, (err) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+  })
+}
+
+async function main(argv) { 
+  const [_0, srcDir, _1, repo, _2, branch, _3, versionFile, _4, ghUser, _5, ghEmail] = argv;
+  const version = await fse.readFile(versionFile, 'utf8');
+  console.log(`Deploying version ${version} to gh-pages`);
+
+  let mainVersion = `${version.split('.')[0]}`
+
+  const currentBranch = execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
+
+  if (version.includes('-next')) {
+    mainVersion = 'next';
+  }
+
+  console.log(`Deploying GH pages to subdirectory: ${mainVersion}`);
+  const isLatestVersion = currentBranch === 'main' && mainVersion !== 'next';
+
+  const config = {
+    branch,
+    repo:  `https://${process.env.GH_TOKEN}@github.com/${repo}.git`,
+    dest: mainVersion,
+    dotFiles: true,
+    add: false,
+    verbose: false,
+    message: `Deploying docs for ${version}`,
+    user: {
+      name: ghUser,
+      email: ghEmail
+    }
+  }
+
+  await deployPages(srcDir, config);
+
+  if (isLatestVersion) {
+    console.log(`Deploying latest version to gh-pages`);
+    await deployPages(srcDir, {
+      ...config,
+      dest: 'latest'
+    });
+  }
+}
+
+main(process.argv.slice(2)).catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/gh-pages/index.bzl
+++ b/gh-pages/index.bzl
@@ -1,0 +1,19 @@
+load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary", "nodejs_test", "npm_package_bin")
+
+def gh_pages(repo, gh_name = 'intuit-svc', gh_email = 'opensource-svc@intuit.com', source_dir="src", branch = "main", **kwargs):
+  nodejs_binary(
+    entry_point = "//gh-pages:gh-pages.js",
+    data = [
+      "@npm//gh-pages",
+      "//:VERSION"
+    ] + kwargs.pop("data", []),
+    args = [
+      "--srcDir", source_dir,
+      "--repo", repo,
+      "--branch", branch,
+      "--version", "$(location //:VERSION)",
+      '--gh_user', gh_name,
+      '--gh_email', gh_email,
+    ],
+    **kwargs
+  )

--- a/gh-pages/index.bzl
+++ b/gh-pages/index.bzl
@@ -2,7 +2,7 @@ load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary", "nodejs_test", "n
 
 def gh_pages(repo, gh_name = 'intuit-svc', gh_email = 'opensource-svc@intuit.com', source_dir="src", branch = "main", **kwargs):
   nodejs_binary(
-    entry_point = "//gh-pages:gh-pages.js",
+    entry_point = "@rules_player//gh-pages:gh-pages.js",
     data = [
       "@npm//gh-pages",
       "//:VERSION"


### PR DESCRIPTION
## Release Notes

Adds a new rule for handling github-pages deployments specific to an organization. 
Releases are organized by major version number, with aliases for the latest release and canary versions. 