### PR TITLE
Add stamp substitution support for nextjs docs

### DIFF
--- a/javascript/next/next.build.js
+++ b/javascript/next/next.build.js
@@ -10,8 +10,33 @@ main(process.argv.slice(2)).catch((err) => {
   process.exitCode = 1;
 });
 
+async function handleSubstitutions(folderOrFile, substitutions) {
+  if (Object.keys(substitutions).length === 0) {
+    return;
+  }
+
+  if (await fse.statSync(folderOrFile).isDirectory()) {
+    const files = await fse.readdir(folderOrFile);
+    for (const file of files) {
+      await handleSubstitutions(path.join(folderOrFile, file), substitutions);
+    }
+
+    return;
+  }
+
+  let contents = await fse.readFile(folderOrFile, 'utf-8');
+  for (const key in substitutions) {
+    const value = substitutions[key];
+    contents = contents.replace(new RegExp(key, 'g'), value);
+  }
+
+  await fse.writeFile(folderOrFile, contents);
+}
+
 async function main(argv) {
-  const [_1, srcDir, _2, outDir, _3, statusFile] = argv;
+  const [_1, srcDir, _2, outDir, _3, sub, _4, statusFile, ] = argv;
+
+  const substitutions = JSON.parse(sub);
 
   if (statusFile) {
     (await fse.readFile(statusFile, 'utf-8')).split('\n').forEach(line => {
@@ -19,6 +44,13 @@ async function main(argv) {
       const varName = line.substring(0, firstSpace);
       const varVal = line.substring(firstSpace + 1);
       process.env[varName] = varVal;
+
+      // Swap out anything referencing the stamped file with the actual value
+      Object.keys(substitutions).forEach(key => {
+        if (substitutions[key] === varName) {
+          substitutions[key] = varVal;
+        }
+      });
     })
   }
 
@@ -35,4 +67,6 @@ async function main(argv) {
   await fse.move(path.join(rootDir, 'out'), distDir, {
     overwrite: true
   });
+
+  await handleSubstitutions(distDir, substitutions);
 }

--- a/javascript/next/next_build.bzl
+++ b/javascript/next/next_build.bzl
@@ -10,6 +10,7 @@ NEXT_ATTRS = dict(NODE_CONTEXT_ATTRS, **{
         allow_files = True,
     ),
     "env": attr.string_dict(),
+    "substitutions": attr.string_dict(),
     "srcs": attr.label_list(default = [], allow_files = True),
     "_next": attr.label(default = Label("//javascript/next:next_build"), executable = True, cfg = "host"),
 })
@@ -36,7 +37,9 @@ def _next_export(ctx):
             "--root-dir",
             ctx.label.package,
             "--out_dir",
-            next_dir.path
+            next_dir.path,
+            "--substitutions",
+            json.encode(ctx.attr.substitutions),
         ] + stamp_args,
         executable = "_next",
         mnemonic = "Next",


### PR DESCRIPTION
Uses a similar mechanism to `pkg_npm` to sub out values during build 