### PR TITLE
Better support for additional package.json attributes

### DIFF
--- a/javascript/README.md
+++ b/javascript/README.md
@@ -70,3 +70,32 @@ The generation and precedence can be though of as:
   ...additional_properties
 }
 ```
+
+### create_contributors
+
+The `create_contributors` rule generates the `package.json` formatted contributors list from an `.all-contributorsrc` file
+
+```python
+load("@rules_player//javascript/package_json:index.bzl", "create_contributors")
+
+create_contributors(
+    name = "pkg_json_contrib",
+    all_contributors = "//:.all-contributorsrc",
+)
+```
+
+### merge_json
+
+The `merge_json` rule will merge together properties from multiple JSON files into one. This can be used as an input to the `base_package_json` attribute.
+
+```python 
+load("@rules_player//javascript/package_json:index.bzl", "merge_json")
+
+merge_json(
+    name = "pkg_json_template",
+    srcs = [
+        "package-template.json",
+        ":pkg_json_contrib",
+    ]
+)
+```

--- a/javascript/js_library_pipeline.bzl
+++ b/javascript/js_library_pipeline.bzl
@@ -32,6 +32,7 @@ def js_library_pipeline(
         lint_exts = [".ts", ".js", ".tsx", ".jsx"],
         js_library_data = [],
         test_env = {},
+        create_package_json_opts = {},
         placeholder_version = PLACEHOLDER_VERSION,
         registry = "https://registry.npmjs.org",
         version_file = "//:VERSION",
@@ -62,6 +63,7 @@ def js_library_pipeline(
         dependencies = dependencies,
         peer_dependencies = peer_dependencies,
         root_package_json = root_package_json,
+        **create_package_json_opts
     )
 
     all_build_data = remove_duplicates(filter_empty(data + BUILD_DATA + build_data + dependencies + peer_dependencies + [":%s" % create_package_json_name, ts_config] + typings))

--- a/javascript/package_json/BUILD
+++ b/javascript/package_json/BUILD
@@ -6,3 +6,8 @@ nodejs_binary(
     name = "create_package_json",
     entry_point = "create_package_json.js",
 )
+
+nodejs_binary(
+    name = "merge_json",
+    entry_point = "merge_json.js",
+)

--- a/javascript/package_json/BUILD
+++ b/javascript/package_json/BUILD
@@ -11,3 +11,8 @@ nodejs_binary(
     name = "merge_json",
     entry_point = "merge_json.js",
 )
+
+nodejs_binary(
+    name = "contributors",
+    entry_point = "contributors.js",
+)

--- a/javascript/package_json/contributors.bzl
+++ b/javascript/package_json/contributors.bzl
@@ -1,0 +1,40 @@
+"""
+Module for building a contributor information about a directory. 
+"""
+
+load("@build_bazel_rules_nodejs//:providers.bzl", "node_modules_aspect", "run_node")
+
+_CREATE_CONTRIBUTORS_JSON = Label("//javascript/package_json:contributors")
+
+create_contribUTORS_ATTRS = {
+  # All contrib src file
+  "all_contributors": attr.label(allow_single_file = [".all-contributorsrc"], ),
+
+  # Internal reference to script to generate the contributors 
+  "_create_contributors": attr.label(default = _CREATE_CONTRIBUTORS_JSON, executable = True, cfg = "host"),
+}
+
+def _create_contributors_impl(ctx):
+    contrib_json = ctx.actions.declare_file("_contributors.json")
+
+    run_node(
+        ctx,
+        inputs = ctx.files.all_contributors,
+        outputs = [contrib_json],
+        arguments = [json.encode({
+          "output_file": contrib_json.path,
+          "all_contributors": ctx.file.all_contributors.path,
+        })],
+        executable = "_create_contributors",
+    )
+
+    return [
+        DefaultInfo(
+            files = depset([contrib_json]),
+        ),
+    ]
+
+create_contributors = rule(
+    implementation = _create_contributors_impl,
+    attrs = create_contribUTORS_ATTRS,
+)

--- a/javascript/package_json/contributors.js
+++ b/javascript/package_json/contributors.js
@@ -1,0 +1,25 @@
+const fs = require("fs");
+const { execSync } = require("child_process");
+
+const main = ([config]) => {
+  const { output_file, all_contributors } = JSON.parse(config);
+  const allContrib = JSON.parse(fs.readFileSync(all_contributors, "utf-8"));
+  const contributors = [];
+
+  allContrib.contributors.forEach(contrib => { 
+    contributors.push({
+      name: contrib.name,
+      url: contrib.profile
+    })
+  })
+
+  fs.writeFileSync(output_file, JSON.stringify({ contributors }, null, 2));
+};
+
+if (require.main === module) {
+  try {
+    process.exitCode = main(process.argv.slice(2));
+  } catch (e) {
+    console.error(process.argv[1], e);
+  }
+}

--- a/javascript/package_json/index.bzl
+++ b/javascript/package_json/index.bzl
@@ -1,0 +1,5 @@
+load(":merge_json.bzl", _merge_json = "merge_json")
+load(":package_json.bzl", _create_package_json = "create_package_json")
+
+merge_json = _merge_json
+create_package_json = _create_package_json

--- a/javascript/package_json/index.bzl
+++ b/javascript/package_json/index.bzl
@@ -1,5 +1,7 @@
 load(":merge_json.bzl", _merge_json = "merge_json")
 load(":package_json.bzl", _create_package_json = "create_package_json")
+load(":contributors.bzl", _create_contributors = "create_contributors")
 
 merge_json = _merge_json
 create_package_json = _create_package_json
+create_contributors = _create_contributors

--- a/javascript/package_json/merge_json.bzl
+++ b/javascript/package_json/merge_json.bzl
@@ -23,14 +23,15 @@ def _merge_json_impl(ctx):
         inputs = ctx.files.srcs,
         outputs = [merged_json],
         arguments = [json.encode({
-          "files": [f.path for f in ctx.files.srcs],
+          "output_file": merged_json.path,
+          "input_files": [f.path for f in ctx.files.srcs],
         })],
         executable = "_merge_json",
     )
 
     return [
         DefaultInfo(
-            files = depset([merge_json]),
+            files = depset([merged_json]),
         ),
     ]
 

--- a/javascript/package_json/merge_json.bzl
+++ b/javascript/package_json/merge_json.bzl
@@ -1,0 +1,40 @@
+"""
+Module for merging multiple JSON files together into one
+"""
+
+load("@build_bazel_rules_nodejs//:providers.bzl", "node_modules_aspect", "run_node")
+
+_MERGE_JSON = Label("//javascript/package_json:merge_json")
+
+MERGE_JSON_ATTRS = {
+  # List of files to merge -- later files will override earlier ones
+  "srcs": attr.label_list(default = [], allow_files = True),
+
+  # Internal reference to script to merge attributes and files together
+  "_merge_json": attr.label(default = _MERGE_JSON, executable = True, cfg = "host"),
+}
+
+
+def _merge_json_impl(ctx):
+    merged_json = ctx.actions.declare_file("merged.json")
+
+    run_node(
+        ctx,
+        inputs = ctx.files.srcs,
+        outputs = [merged_json],
+        arguments = [json.encode({
+          "files": [f.path for f in ctx.files.srcs],
+        })],
+        executable = "_merge_json",
+    )
+
+    return [
+        DefaultInfo(
+            files = depset([merge_json]),
+        ),
+    ]
+
+merge_json = rule(
+    implementation = _merge_json_impl,
+    attrs = MERGE_JSON_ATTRS,
+)

--- a/javascript/package_json/merge_json.js
+++ b/javascript/package_json/merge_json.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+
+const main = ([config]) => {
+  const { input_files, output_file } = JSON.parse(config);
+  let merged_json = {};
+
+  input_files.forEach(file => { 
+    const json = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    merged_json = {
+      ...merged_json,
+      ...json,
+    }
+  });
+
+  fs.writeFileSync(output_file, JSON.stringify(merged_json, null, 2));
+};
+
+if (require.main === module) {
+  try {
+    process.exitCode = main(process.argv.slice(2));
+  } catch (e) {
+    console.error(process.argv[1], e);
+  }
+}


### PR DESCRIPTION
## Release Notes

Adds new rules to the `package.json` creation pipeline:

Adds `merge_json` rule to flatten multiple `json` files into one. This can be combined with the `base_package_json` attribute to create more dynamic package attributes. 

Adds a `create_contributors` rule for generating the `contributors` section of a `package.json` from an `.all-contributorsrc`


Example: 
```python
load("@rules_player//javascript/package_json:index.bzl", "merge_json", "create_contributors")

create_contributors(
    name = "pkg_json_contrib",
    all_contributors = "//:.all-contributorsrc",
)

merge_json(
    name = "pkg_json_template",
    srcs = [
        "package-template.json",
        ":pkg_json_contrib",
    ]
)
```