### PR TITLE
flip ternary logic for templates

### DIFF
--- a/cocoapods/cocoapod.bzl
+++ b/cocoapods/cocoapod.bzl
@@ -140,7 +140,7 @@ def _pod_push_impl(ctx):
   commands = ctx.attr.executable.split(' ')
 
   ctx.actions.expand_template(
-    template = ctx.file._templateTrunk if ctx.attr.repository == None else ctx.file._templatePrivateRepo,
+    template = ctx.file._templatePrivateRepo if ctx.attr.repository else ctx.file._templateTrunk,
     output = output,
     is_executable = True,
     substitutions = {


### PR DESCRIPTION
use truthy/falsy instead of strict comparison

maybe `ctx.attr.X` returns a struct?