### PR TITLE
Update gh_pages and enable tarball stamping

### DIFF
--- a/distribution/index.bzl
+++ b/distribution/index.bzl
@@ -1,0 +1,22 @@
+load("@rules_player//distribution/tar:stamp_tar_files.bzl", "stamp_tar_files")
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+
+def pkg_stamped_tar(name, substitutions = {}, visibility = None, **kwargs):
+  """
+  Creates a tar.gz file in which all files are stamped with the given substitutions.
+  """
+  base_name = "%s_base" % name
+  base_target = ":%s" % base_name
+
+  pkg_tar(
+    # TODO: Add visibility here
+    name = base_name,
+    **kwargs,
+  )
+
+  stamp_tar_files(
+    name = name,
+    substitutions = substitutions,
+    visibility = visibility,
+    tar = base_target
+  )

--- a/distribution/tar/BUILD
+++ b/distribution/tar/BUILD
@@ -1,0 +1,11 @@
+load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+nodejs_binary(
+    name = "stamp_tar_files",
+    entry_point = "stamp_tar_files.js",
+    data = [
+      "@npm//tar"
+    ]
+)

--- a/distribution/tar/stamp_tar_files.bzl
+++ b/distribution/tar/stamp_tar_files.bzl
@@ -1,0 +1,50 @@
+"""
+Module for stamping a tar.gz file and repackaging it
+"""
+load("@build_bazel_rules_nodejs//:providers.bzl", "run_node", "NODE_CONTEXT_ATTRS", "NodeContextInfo")
+load("@bazel_skylib//lib:paths.bzl", "paths")
+
+_stamp_tar_files = Label("//distribution/tar:stamp_tar_files")
+
+TAR_STAMP_ATTRS = dict(NODE_CONTEXT_ATTRS, **{
+  "tar": attr.label( allow_single_file=True ),
+  "substitutions": attr.string_dict(),
+  "_stamp_tar_files": attr.label(default=_stamp_tar_files, executable=True, cfg="host"),
+})
+
+def _stamp_tar_impl(ctx):
+  """
+  Untar it, stamp the items, and repack
+  """
+  stamped_tar = ctx.actions.declare_file(paths.basename(ctx.attr.name + '.tar'))
+  
+  stamp_inputs = []
+  stamp = ctx.attr.node_context_data[NodeContextInfo].stamp
+
+  if stamp:
+      stamp_inputs = [ctx.info_file]
+
+  run_node(
+      ctx,
+      inputs = ctx.files.tar + stamp_inputs,
+      outputs = [stamped_tar],
+      arguments = [json.encode({
+        "input_file": ctx.file.tar.path,
+        "output_file": stamped_tar.path,
+        "stamp": ctx.info_file.path if stamp else None,
+        "substitutions": ctx.attr.substitutions,
+      })],
+      executable = "_stamp_tar_files",
+      mnemonic = "tar",
+  )
+
+  return [
+    DefaultInfo(
+      files = depset([stamped_tar])
+    )
+  ]
+
+stamp_tar_files = rule(
+  implementation = _stamp_tar_impl,
+  attrs = TAR_STAMP_ATTRS,
+)

--- a/distribution/tar/stamp_tar_files.bzl
+++ b/distribution/tar/stamp_tar_files.bzl
@@ -16,7 +16,7 @@ def _stamp_tar_impl(ctx):
   """
   Untar it, stamp the items, and repack
   """
-  stamped_tar = ctx.actions.declare_file(paths.basename(ctx.attr.name + '.tar'))
+  stamped_tar = ctx.actions.declare_file(paths.basename(ctx.attr.name + '.tar.gz'))
   
   stamp_inputs = []
   stamp = ctx.attr.node_context_data[NodeContextInfo].stamp

--- a/distribution/tar/stamp_tar_files.js
+++ b/distribution/tar/stamp_tar_files.js
@@ -1,0 +1,96 @@
+const fs = require("fs");
+const path = require("path");
+const tar = require('tar');
+
+async function handleSubstitutions(folderOrFile, substitutions) {
+  if (Object.keys(substitutions).length === 0) {
+    return;
+  }
+
+  if ((await fs.promises.stat(folderOrFile)).isDirectory()) {
+    const files = await fs.promises.readdir(folderOrFile);
+    for (const file of files) {
+      await handleSubstitutions(path.join(folderOrFile, file), substitutions);
+    }
+
+    return;
+  }
+
+  let contents = await fs.promises.readFile(folderOrFile, "utf-8");
+  const originalContents = contents;
+  for (const key in substitutions) {
+    const value = substitutions[key];
+    contents = contents.replace(new RegExp(key, "g"), value);
+  }
+  
+  if (contents !== originalContents) {
+    await fs.promises.writeFile(folderOrFile, contents);
+  }
+}
+
+const repackageTar = async (input_file, output_file, substitutions) => {
+  const tempDir = path.join(__dirname, "temp");
+  await fs.promises.mkdir(tempDir, { recursive: true });
+
+  // await extract(input_file, { dir: tempDir });
+
+  await tar.extract({
+    cwd: tempDir,
+    file: input_file,
+  });
+
+  await handleSubstitutions(tempDir, substitutions);
+
+  await tar.create({
+    file: output_file,
+    cwd: tempDir
+  }, [tempDir]);
+
+  await fs.promises.rm(tempDir, { recursive: true });
+};
+
+const main = async ([config]) => {
+  const { input_file, output_file, stamp, substitutions } = JSON.parse(config);
+
+  // Don't do much if we don't have to stamp, just copy it over as is
+  if (!stamp) {
+    fs.copyFileSync(input_file, output_file);
+    return;
+  }
+
+  // Grab all of the vars to stamp
+  // untar the file
+  // Replace what needs to be replaced
+  // retar it to the new location
+  const stampFile = fs.readFileSync(stamp, "utf-8");
+
+  // TODO: Should share this as a common module
+  stampFile.split("\n").forEach((line) => {
+    const firstSpace = line.indexOf(" ");
+    const varName = line.substring(0, firstSpace);
+    let varVal = line.substring(firstSpace + 1);
+
+    // Using the same match as https://github.com/bazelbuild/rules_nodejs/blob/stable/internal/pkg_npm/packager.js#L139
+    if (varName.endsWith('_VERSION')) {
+      // vscode doesn't let you have `-canary` suffixes
+      varVal = varVal.replace(/[^\d.]/g, '');
+    }
+
+    // Swap out anything referencing the stamped file with the actual value
+    Object.keys(substitutions).forEach((key) => {
+      if (substitutions[key] === `{${varName}}`) {
+        substitutions[key] = varVal;
+      }
+    });
+  });
+
+  await repackageTar(input_file, output_file, substitutions);
+};
+
+if (require.main === module) {
+  try {
+    process.exitCode = main(process.argv.slice(2));
+  } catch (e) {
+    console.error(process.argv[1], e);
+  }
+}

--- a/distribution/tar/stamp_tar_files.js
+++ b/distribution/tar/stamp_tar_files.js
@@ -45,14 +45,8 @@ const repackageTar = async (input_file, output_file, substitutions) => {
   await tar.create({
     file: output_file,
     cwd: tempOutputDir,
+    gzip: true,
   }, ['.']);
-
-  console.log({
-    tempTar,
-    tempOutputDir,
-    input_file,
-    tempDir,
-  })
 };
 
 const main = async ([config]) => {
@@ -89,8 +83,6 @@ const main = async ([config]) => {
       }
     });
   });
-
-  console.log({ substitutions })
 
   await repackageTar(input_file, output_file, substitutions);
 };

--- a/gh-pages/gh-pages.js
+++ b/gh-pages/gh-pages.js
@@ -43,6 +43,8 @@ async function main(args) {
     dest_dir,
   } = args;
 
+  const normalized_dest_dir = String(dest_dir);
+
   const version = await fs.promises.readFile(version_file, "utf8");
   let cleanup = false;
   let upload_root = srcDir;
@@ -52,14 +54,14 @@ async function main(args) {
     upload_root = await expandTarball(srcDir);
   }
 
-  if (!dest_dir) {
+  if (!normalized_dest_dir) {
     throw new Error("Unable to upload without a destination directory");
   }
 
   const config = {
     branch,
     repo: `https://${process.env.GH_TOKEN}@github.com/${repo}.git`,
-    dest: dest_dir,
+    dest: normalized_dest_dir,
     dotFiles: true,
     add: false,
     verbose: false,

--- a/gh-pages/gh-pages.js
+++ b/gh-pages/gh-pages.js
@@ -1,6 +1,8 @@
+const yargs = require('yargs/yargs')
+const { hideBin } = require('yargs/helpers');
 const fse = require('fs-extra');
 const ghPages = require('gh-pages');
-const { execSync } = require('child_process');
+const tar = require('tar');
 
 async function deployPages(dir, config) {
   return new Promise((resolve, reject) => { 
@@ -14,48 +16,77 @@ async function deployPages(dir, config) {
   })
 }
 
-async function main(argv) { 
-  const [_0, srcDir, _1, repo, _2, branch, _3, versionFile, _4, ghUser, _5, ghEmail] = argv;
-  const version = await fse.readFile(versionFile, 'utf8');
+async function expandTarball(tarball) {
+  const tempDir = path.join(__dirname, "temp");
+  await fs.promises.mkdir(tempDir, { recursive: true });
+
+  await tar.extract({
+    cwd: tempDir,
+    file: tarball,
+  });
+
+  return tempDir
+}
+
+const isTarball = (file) => file.endsWith('.tar.gz') || file.endsWith('.tar') || file.endsWith('.tar.xz');
+
+async function main(args) {
+  const {
+    srcDir, repo, branch, version: version_file, gh_user, gh_email, dest_dir, 
+  } = args;
+
+  let cleanup = false;
+  let upload_root = srcDir;
+
+  if (isTarball(srcDir)) {
+    cleanup = true;
+    upload_root = await expandTarball(srcDir);
+  }
+
+  const version = await fse.readFile(version_file, 'utf8');
   console.log(`Deploying version ${version} to gh-pages`);
 
   let mainVersion = `${version.split('.')[0]}`
-
-  const currentBranch = execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
-
   if (version.includes('-next')) {
     mainVersion = 'next';
   }
 
   console.log(`Deploying GH pages to subdirectory: ${mainVersion}`);
-  const isLatestVersion = currentBranch === 'main' && mainVersion !== 'next';
 
   const config = {
     branch,
     repo:  `https://${process.env.GH_TOKEN}@github.com/${repo}.git`,
-    dest: mainVersion,
+    dest: dest_dir || mainVersion,
     dotFiles: true,
     add: false,
     verbose: false,
     message: `Deploying docs for ${version}`,
     user: {
-      name: ghUser,
-      email: ghEmail
+      name: gh_user,
+      email: gh_email
     }
   }
 
   await deployPages(srcDir, config);
 
-  if (isLatestVersion) {
-    console.log(`Deploying latest version to gh-pages`);
-    await deployPages(srcDir, {
-      ...config,
-      dest: 'latest'
-    });
+  if (cleanup) {
+    await fs.promises.rm(upload_root, { recursive: true });
   }
+
+  // const currentBranch = execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
+  // const isLatestVersion = currentBranch === 'main' && mainVersion !== 'next';
+  // if (isLatestVersion) {
+  //   console.log(`Deploying latest version to gh-pages`);
+  //   await deployPages(srcDir, {
+  //     ...config,
+  //     dest: 'latest'
+  //   });
+  // }
 }
 
-main(process.argv.slice(2)).catch((err) => {
+const parsed = yargs(hideBin(process.argv)).version(false).parse();
+
+main(parsed).catch((err) => {
   console.error(err);
   process.exitCode = 1;
 });

--- a/gh-pages/gh-pages.js
+++ b/gh-pages/gh-pages.js
@@ -1,11 +1,12 @@
-const yargs = require('yargs/yargs')
-const { hideBin } = require('yargs/helpers');
-const fse = require('fs-extra');
-const ghPages = require('gh-pages');
-const tar = require('tar');
+const yargs = require("yargs/yargs");
+const { hideBin } = require("yargs/helpers");
+const fs = require("fs");
+const ghPages = require("gh-pages");
+const path = require("path");
+const tar = require("tar");
 
 async function deployPages(dir, config) {
-  return new Promise((resolve, reject) => { 
+  return new Promise((resolve, reject) => {
     ghPages.publish(dir, config, (err) => {
       if (err) {
         reject(err);
@@ -13,7 +14,7 @@ async function deployPages(dir, config) {
         resolve();
       }
     });
-  })
+  });
 }
 
 async function expandTarball(tarball) {
@@ -25,16 +26,24 @@ async function expandTarball(tarball) {
     file: tarball,
   });
 
-  return tempDir
+  return tempDir;
 }
 
-const isTarball = (file) => file.endsWith('.tar.gz') || file.endsWith('.tar') || file.endsWith('.tar.xz');
+const isTarball = (file) =>
+  file.endsWith(".tar.gz") || file.endsWith(".tar") || file.endsWith(".tar.xz");
 
 async function main(args) {
   const {
-    srcDir, repo, branch, version: version_file, gh_user, gh_email, dest_dir, 
+    srcDir,
+    repo,
+    branch,
+    version: version_file,
+    gh_user,
+    gh_email,
+    dest_dir,
   } = args;
 
+  const version = await fs.promises.readFile(version_file, "utf8");
   let cleanup = false;
   let upload_root = srcDir;
 
@@ -43,45 +52,29 @@ async function main(args) {
     upload_root = await expandTarball(srcDir);
   }
 
-  const version = await fse.readFile(version_file, 'utf8');
-  console.log(`Deploying version ${version} to gh-pages`);
-
-  let mainVersion = `${version.split('.')[0]}`
-  if (version.includes('-next')) {
-    mainVersion = 'next';
+  if (!dest_dir) {
+    throw new Error("Unable to upload without a destination directory");
   }
-
-  console.log(`Deploying GH pages to subdirectory: ${mainVersion}`);
 
   const config = {
     branch,
-    repo:  `https://${process.env.GH_TOKEN}@github.com/${repo}.git`,
-    dest: dest_dir || mainVersion,
+    repo: `https://${process.env.GH_TOKEN}@github.com/${repo}.git`,
+    dest: dest_dir,
     dotFiles: true,
     add: false,
     verbose: false,
     message: `Deploying docs for ${version}`,
     user: {
       name: gh_user,
-      email: gh_email
-    }
-  }
+      email: gh_email,
+    },
+  };
 
-  await deployPages(srcDir, config);
+  await deployPages(upload_root, config);
 
   if (cleanup) {
     await fs.promises.rm(upload_root, { recursive: true });
   }
-
-  // const currentBranch = execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
-  // const isLatestVersion = currentBranch === 'main' && mainVersion !== 'next';
-  // if (isLatestVersion) {
-  //   console.log(`Deploying latest version to gh-pages`);
-  //   await deployPages(srcDir, {
-  //     ...config,
-  //     dest: 'latest'
-  //   });
-  // }
 }
 
 const parsed = yargs(hideBin(process.argv)).version(false).parse();


### PR DESCRIPTION
Updates the `gh_pages` rule to work with a supplied `.tar.gz` (in addition to a directory)