### PR TITLE
Externalize entrypoint for webpack bundle

### DIFF
--- a/player/bundle/bundle.bzl
+++ b/player/bundle/bundle.bzl
@@ -1,5 +1,5 @@
 load("@npm//webpack-cli:index.bzl", _webpack = "webpack_cli")
-
+load("@rules_player//javascript:utils.bzl", "filter_empty")
 PROD = "prod"
 DEV = "dev"
 
@@ -11,19 +11,19 @@ MODES = {
     DEV: DEVELOPMENT,
 }
 
-def webpack(name, dist, deps, mode_shorthand, visibility, bundle_entry, bundle_name = None, **kwargs):
+def webpack(name, dist, deps, mode_shorthand, visibility, bundle_entry = None, bundle_name = None, **kwargs):
     output_name = bundle_name if bundle_name != None else name
     _webpack(
         name = "%s_bundle_%s" % (name, mode_shorthand),
         outs = ["dist/%s.%s.js" % (bundle_name, mode_shorthand)],
-        args = [
+        args = filter_empty([
             "--mode %s" % MODES[mode_shorthand],
             bundle_entry,
             "--config",
             "webpack.config.js",
             "-o",
             "./$@",
-        ],
+        ]),
         data = dist + deps,
         visibility = visibility,
         **kwargs
@@ -33,7 +33,7 @@ def webpack(name, dist, deps, mode_shorthand, visibility, bundle_entry, bundle_n
 Creates dev and prod bundles from cjs code
 """
 
-def bundle(name, dist, deps, visibility, bundle_entry, bundle_name = None, **kwargs):
+def bundle(name, dist, deps, visibility, bundle_entry = None, bundle_name = None, **kwargs):
     """Wrapper to create dev and prod bundles from a ts_package"""
     webpack(name, dist, deps, DEV, visibility, bundle_entry, bundle_name, **kwargs)
     webpack(name, dist, deps, PROD, visibility, bundle_entry, bundle_name, **kwargs)

--- a/player/bundle/bundle.bzl
+++ b/player/bundle/bundle.bzl
@@ -11,14 +11,14 @@ MODES = {
     DEV: DEVELOPMENT,
 }
 
-def webpack(name, dist, deps, mode_shorthand, visibility, bundle_name = None, **kwargs):
+def webpack(name, dist, deps, mode_shorthand, visibility, bundle_entry, bundle_name = None, **kwargs):
     output_name = bundle_name if bundle_name != None else name
     _webpack(
         name = "%s_bundle_%s" % (name, mode_shorthand),
         outs = ["dist/%s.%s.js" % (bundle_name, mode_shorthand)],
         args = [
             "--mode %s" % MODES[mode_shorthand],
-            "./$(RULEDIR)",
+            bundle_entry,
             "--config",
             "webpack.config.js",
             "-o",
@@ -33,10 +33,10 @@ def webpack(name, dist, deps, mode_shorthand, visibility, bundle_name = None, **
 Creates dev and prod bundles from cjs code
 """
 
-def bundle(name, dist, deps, visibility, bundle_name = None, **kwargs):
+def bundle(name, dist, deps, visibility, bundle_entry, bundle_name = None, **kwargs):
     """Wrapper to create dev and prod bundles from a ts_package"""
-    webpack(name, dist, deps, DEV, visibility, bundle_name, **kwargs)
-    webpack(name, dist, deps, PROD, visibility, bundle_name, **kwargs)
+    webpack(name, dist, deps, DEV, visibility, bundle_entry, bundle_name, **kwargs)
+    webpack(name, dist, deps, PROD, visibility, bundle_entry, bundle_name, **kwargs)
 
     native.filegroup(
         name = name,


### PR DESCRIPTION
Make the entry point for the `bundle` macro a parameter of the function to allow a file/directory be specified by the caller instead of set by the macro. This will give us the flexibility to specify alternative entry points (for example in the use of adding polyfills) to webpack bundles. 

## Release Notes
Webpack bundle macro now requires an entrypoint to be supplied. 