### PR TITLE
`maven_install` for publishing to local Maven repository

### DIFF
--- a/kotlin/distribution.bzl
+++ b/kotlin/distribution.bzl
@@ -1,4 +1,4 @@
-load("@vaticle_bazel_distribution//maven:rules.bzl", "assemble_maven", "deploy_maven")
+load("@vaticle_bazel_distribution//maven:rules.bzl", "assemble_maven", "deploy_maven", "MavenDeploymentInfo")
 load("//internal:scope_name.bzl", "scope_name")
 
 def distribution(
@@ -31,9 +31,37 @@ def distribution(
         workspace_refs = workspace_refs,
     )
 
+    install_maven(
+        name = scope_name(name, "install"),
+        target = ":%s" % assemble_name,
+    )
+
     deploy_maven(
         name = scope_name(name, "deploy"),
         target = ":%s" % assemble_name,
         release = release_repo,
         snapshot = snapshot_repo,
     )
+
+def _install_maven_impl(ctx):
+    deployment_info = ctx.attr.target[MavenDeploymentInfo]
+    file = deployment_info.jar
+
+    script = ctx.actions.declare_file("%s-install" % ctx.label.name)
+    script_content = "mvn install:install-file -Dfile={}".format(file.short_path,)
+    ctx.actions.write(script, script_content, is_executable = True)
+
+    runfiles = ctx.runfiles(files = [file])
+    return [DefaultInfo(executable = script, runfiles = runfiles)]
+
+install_maven = rule(
+    implementation = _install_maven_impl,
+    attrs = {
+        "target": attr.label(
+            mandatory = True,
+            providers = [MavenDeploymentInfo],
+            doc = "assemble_maven target to install",
+        ),
+    },
+    executable = True,
+)

--- a/kotlin/kt_jvm.bzl
+++ b/kotlin/kt_jvm.bzl
@@ -67,8 +67,8 @@ def kt_jvm(
     snapshot and release repositories to publish to. Additionally, a version file is
     required to read the version from for publishing.
 
-    If any of these properties are provided, publishing will be attempted, but will
-    error out if any of the additional properties are missing.
+    If any of these properties are provided, publishing targets will be attempted to be
+    created, but will error out if any of the other required properties are missing.
 
     The following can be provided for additional information to publish the artifact
     with:
@@ -76,6 +76,11 @@ def kt_jvm(
     - project_description
     - project_url
     - scm_url
+
+    Three targets are created for publishing:
+    - {name}-assemble: Package artifact and generate POM
+    - {name}-deploy: Executable target for actually deploying to a Maven repo
+    - {name}-install: Exectuable target to locally install the artifacts
 
     Args:
         name: used for the underlying `kt_jvm_library` rule


### PR DESCRIPTION
# Release Notes

`maven_install` rule that installs an artifact to the consumers local Maven repository (typically `~/.m2/repository`). The target must provide `MavenDeploymentInfo` (i.e. `assemble_maven` targets).

This is tied into the top-level `kt_jvm` macro and will generate a target if `distribution` is configured.