### PR TITLE
Bazel 6 xlr

### DIFF
--- a/javascript/private/js_pipeline.bzl
+++ b/javascript/private/js_pipeline.bzl
@@ -26,6 +26,7 @@ def js_pipeline(
         native_bundle = None,
         private = False,
         peer_deps = [],
+        include_packaging_targets = [],
         test_deps = ["//:vitest_config"],
         lint_deps = ["//:eslint_config"],
         build_deps = ["//:tsup_config", "//:typings"]):
@@ -163,7 +164,7 @@ def js_pipeline(
         name = name,
         visibility = ["//visibility:public"],
         package = package_name,
-        srcs = [js_library_target, tsup_build_target],
+        srcs = [js_library_target, tsup_build_target] + include_packaging_targets,
         tags = filter_empty([
             "do-not-publish" if private else None,
         ]),

--- a/player/defs.bzl
+++ b/player/defs.bzl
@@ -3,7 +3,10 @@ Public API for player Bazel rules.
 """
 
 load("//player/private:dsl.bzl", _compile = "compile")
+load("//player/private:xlr.bzl", _xlr_compile = "xlr_compile")
 load("//player/private:config.bzl", _create_base_config = "create_base_config")
 
 compile = _compile
+dsl_compile = _compile
+xlr_compile = _xlr_compile
 create_base_config = _create_base_config

--- a/player/defs.bzl
+++ b/player/defs.bzl
@@ -5,8 +5,10 @@ Public API for player Bazel rules.
 load("//player/private:dsl.bzl", _compile = "compile")
 load("//player/private:xlr.bzl", _xlr_compile = "xlr_compile")
 load("//player/private:config.bzl", _create_base_config = "create_base_config")
+load("//player/private:js_xlr_pipeline.bzl", _js_xlr_pipeline = "js_xlr_pipeline")
 
 compile = _compile
 dsl_compile = _compile
 xlr_compile = _xlr_compile
 create_base_config = _create_base_config
+js_xlr_pipeline = _js_xlr_pipeline

--- a/player/private/BUILD
+++ b/player/private/BUILD
@@ -7,6 +7,12 @@ bzl_library(
 )
 
 bzl_library(
+    name = "xlr",
+    srcs = ["xlr.bzl"],
+    visibility = ["//player:__subpackages__"],
+)
+
+bzl_library(
     name = "config",
     srcs = ["config.bzl"],
     visibility = ["//player:__subpackages__"],

--- a/player/private/dsl.bzl
+++ b/player/private/dsl.bzl
@@ -6,7 +6,7 @@ load("@aspect_bazel_lib//lib:directory_path.bzl", "directory_path")
 load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_run_binary", "js_test")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 
-def compile(name, node_modules = "//:node_modules", srcs = None, data = [], config = None, skip_test = False, **kwargs):
+def compile(name, node_modules = "//:node_modules", srcs = None, input_dir = "src", data = [], config = None, skip_test = False, **kwargs):
     """Run the src or src_dir through the player compiler.
     Args:
         name: The name of the target.
@@ -30,8 +30,6 @@ def compile(name, node_modules = "//:node_modules", srcs = None, data = [], conf
         data = ["{}/@player-tools/cli".format(node_modules)],
         entry_point = ":{}".format(player_cli_entrypoint),
     )
-
-    input_dir = paths.dirname(srcs[0])
 
     outputs = [paths.join("{}_dist".format(name), paths.relativize(paths.replace_extension(src, ".json"), input_dir)) for src in srcs]
 

--- a/player/private/js_xlr_pipeline.bzl
+++ b/player/private/js_xlr_pipeline.bzl
@@ -1,0 +1,34 @@
+load("//javascript:defs.bzl", "js_pipeline")
+load("xlr.bzl", "xlr_compile")
+
+def js_xlr_pipeline(name = None, xlr_mode = "plugin", xlr_input_dir = "src", srcs = None, **kwargs):
+    """A rule for compiling player flows with xlr mode.
+    Args:
+        name: The name of the target.
+        xlr_mode: The mode to use when compiling with XLR. Defaults to "plugin".
+    """
+
+    if name == None:
+        # name = package_name.split("/")[-1]
+        name = native.package_name().split("/")[-1]
+
+    if srcs == None:
+        srcs = native.glob(["src/**/*"])
+
+    xlr_compile(
+        name = name + "_xlr",
+        srcs = srcs,
+        mode = xlr_mode,
+        input_dir = xlr_input_dir,
+        data = [
+            "//:node_modules/dlv",
+        ] + kwargs.get("deps", []) + kwargs.get("peer_deps", []),
+    )
+
+    js_pipeline(
+        name = name,
+        include_packaging_targets = [
+            ":" + name + "_xlr",
+        ],
+        **kwargs
+    )

--- a/player/private/xlr.bzl
+++ b/player/private/xlr.bzl
@@ -5,7 +5,6 @@ A rule for compiling player flows.
 load("@aspect_bazel_lib//lib:directory_path.bzl", "directory_path")
 load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_run_binary")
 load("config.bzl", "create_base_config")
-load("@bazel_skylib//lib:paths.bzl", "paths")
 
 def xlr_compile(
         name,
@@ -13,6 +12,7 @@ def xlr_compile(
         srcs = None,
         data = [],
         config = None,
+        input_dir = "src",
         mode = "plugin",
         **kwargs):
     player_cli_entrypoint = "{}_entrypoint".format(name)
@@ -36,8 +36,6 @@ def xlr_compile(
         data = ["{}/@player-tools/cli".format(node_modules)],
         entry_point = ":{}".format(player_cli_entrypoint),
     )
-
-    input_dir = paths.dirname(srcs[0])
 
     js_run_binary(
         name = name,

--- a/player/private/xlr.bzl
+++ b/player/private/xlr.bzl
@@ -5,6 +5,7 @@ A rule for compiling player flows.
 load("@aspect_bazel_lib//lib:directory_path.bzl", "directory_path")
 load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_run_binary")
 load("config.bzl", "create_base_config")
+load("@bazel_skylib//lib:paths.bzl", "paths")
 
 def xlr_compile(
         name,
@@ -46,14 +47,14 @@ def xlr_compile(
             "xlr",
             "compile",
             "-o",
-            native.package_name(),
+            paths.join(native.package_name(), "dist"),
             "-i",
-            "{}/{}".format(native.package_name(), input_dir),
+            paths.join(native.package_name(), input_dir),
             "-c",
             "$(rootpath {})".format(config),
             "-m",
             mode,
         ],
-        out_dirs = ["xlr"],
+        out_dirs = [paths.join("dist", "xlr")],
         **kwargs
     )

--- a/player/private/xlr.bzl
+++ b/player/private/xlr.bzl
@@ -1,0 +1,61 @@
+"""
+A rule for compiling player flows.
+"""
+
+load("@aspect_bazel_lib//lib:directory_path.bzl", "directory_path")
+load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_run_binary")
+load("config.bzl", "create_base_config")
+load("@bazel_skylib//lib:paths.bzl", "paths")
+
+def xlr_compile(
+        name,
+        node_modules = "//:node_modules",
+        srcs = None,
+        data = [],
+        config = None,
+        mode = "plugin",
+        **kwargs):
+    player_cli_entrypoint = "{}_entrypoint".format(name)
+
+    if (config == None):
+        create_base_config(
+            name = "{}_config".format(name),
+        )
+        config = ":{}_config".format(name)
+
+    directory_path(
+        name = player_cli_entrypoint,
+        directory = "{}/@player-tools/cli/dir".format(node_modules),
+        path = "bin/run",
+    )
+
+    js_bin_name = "{}_binary".format(name)
+
+    js_binary(
+        name = js_bin_name,
+        data = ["{}/@player-tools/cli".format(node_modules)],
+        entry_point = ":{}".format(player_cli_entrypoint),
+    )
+
+    input_dir = paths.dirname(srcs[0])
+
+    js_run_binary(
+        name = name,
+        tool = js_bin_name,
+        srcs = data + srcs + [config],
+        visibility = ["//:__subpackages__"],
+        args = [
+            "xlr",
+            "compile",
+            "-o",
+            native.package_name(),
+            "-i",
+            "{}/{}".format(native.package_name(), input_dir),
+            "-c",
+            "$(rootpath {})".format(config),
+            "-m",
+            mode,
+        ],
+        out_dirs = ["xlr"],
+        **kwargs
+    )


### PR DESCRIPTION
Builds off of #44 to include support for XLR generation in JS rules. 