### PR TITLE
add generic stamp rule back in to stamp Podspec

### DIFF
--- a/internal/BUILD
+++ b/internal/BUILD
@@ -1,0 +1,10 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+exports_files(["defs.bzl"])
+
+bzl_library(
+    name = "defs",
+    srcs = ["defs.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [],
+)

--- a/internal/defs.bzl
+++ b/internal/defs.bzl
@@ -1,0 +1,7 @@
+"""
+Public API for Utility rules
+"""
+
+load("//internal/private:stamp.bzl", _stamp = "stamp")
+
+stamp = _stamp

--- a/internal/private/BUILD
+++ b/internal/private/BUILD
@@ -1,0 +1,20 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@aspect_rules_js//js:defs.bzl", "js_binary")
+
+
+bzl_library(
+    name = "stamp",
+    srcs = ["stamp.bzl"],
+    visibility = [
+        "//docs:__subpackages__",
+        "//internal:__subpackages__",
+    ],
+    deps = [
+    ],
+)
+
+js_binary(
+    name = "stamp_replacement_script",
+    entry_point = "stamp_replacement.js",
+    visibility = ["//visibility:public"],
+)

--- a/internal/private/stamp.bzl
+++ b/internal/private/stamp.bzl
@@ -1,0 +1,67 @@
+load("@aspect_bazel_lib//lib:stamping.bzl", "STAMP_ATTRS", "maybe_stamp")
+
+_STAMP = Label("//internal/private:stamp_replacement_script")
+
+def _stamp_impl(ctx):
+  inputs = []
+
+  outputs = []
+
+  for file in ctx.files.files:
+    outputs.append(ctx.actions.declare_file(file.basename))
+
+  stamp = maybe_stamp(ctx)
+  args = {
+    "files": [f.path for f in ctx.files.files],
+    "outputs": [f.path for f in outputs],
+    "substitutions": ctx.attr.substitutions,
+    "stable": ctx.attr.stable
+  }
+
+  if stamp:
+    inputs = [stamp.volatile_status_file, stamp.stable_status_file]
+    args["info_file"] = stamp.stable_status_file.path
+    args["version_file"] = stamp.volatile_status_file.path
+
+
+  ctx.actions.run(
+    inputs = inputs + ctx.files.files,
+    outputs = outputs,
+    arguments = [
+      json.encode(args)
+    ],
+    env = {
+      "BAZEL_BINDIR": ctx.bin_dir.path,
+    },
+    executable = ctx.executable._stamp_exec
+  )
+
+  return [
+    DefaultInfo(
+      files = depset(outputs)
+    )
+  ]
+
+stamp = rule(
+  implementation = _stamp_impl,
+  attrs = dict({
+    "files": attr.label_list(
+      allow_files = True,
+      mandatory = True,
+      doc = "The files to stamp"
+    ),
+    "substitutions": attr.string_dict(
+      doc = "A mapping of values to replace in a file, to the stamp variables"
+    ),
+    "stable": attr.bool(
+      default = False,
+      doc = "Whether to replace variables from stable-status or volatile-status"
+    ),
+    "_stamp_exec": attr.label(
+      default = _STAMP,
+      executable = True,
+      doc = "The executable to run the stamping",
+      cfg = "exec"
+    )
+  }, **STAMP_ATTRS)
+)

--- a/internal/private/stamp_replacement.js
+++ b/internal/private/stamp_replacement.js
@@ -1,0 +1,51 @@
+const fs = require("fs");
+const process = require("process");
+const path = require('path')
+
+const main = ([config]) => {
+  const {
+    stable = false,
+    substitutions = {},
+    version_file,
+    info_file,
+    files = [],
+    outputs = []
+  } = JSON.parse(config);
+
+  const fileToRead = stable ? info_file : version_file
+
+  process.chdir(process.env.JS_BINARY__EXECROOT)
+
+  const variables = fileToRead ? 
+  fs.readFileSync(fileToRead)
+    .toString()
+    .trim()
+    .split('\n')
+    .map(line => line.split(' '))
+    .reduce((acc, cv) => ({...acc, ...{[`{${cv[0]}}`]: cv[1]}}))
+  : {}
+
+
+  files.forEach( f => {
+    const outputLocation = outputs.find((o) => o.includes(f))
+    if (outputLocation) {
+      fs.mkdirSync(path.dirname(outputLocation), { recursive: true})
+    }
+    const contents = fs.readFileSync(f).toString()
+    const newContents = Object.keys(substitutions).reduce((acc, cv) => {
+      const subValue = variables[substitutions[cv]]
+      return subValue ? acc.replace(cv, subValue) : acc
+    }, contents)
+
+    fs.writeFileSync(outputLocation, newContents)
+  })
+}
+
+
+if (require.main === module) {
+  try {
+    process.exitCode = main(process.argv.slice(2));
+  } catch (e) {
+    console.error(process.argv[1], e);
+  }
+}


### PR DESCRIPTION
ported previous `stamp` rule for podspec stamping to use aspect rules for execution