### PR TITLE
iOS: Move over common utils.bzl macros to be reused for playerplugins

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,3 +16,8 @@ rules_ts_ext = use_extension(
 rules_ts_ext.deps()
 
 use_repo(rules_ts_ext, "npm_typescript")
+
+## Rule Dependencies
+bazel_dep(name = "rules_swift", version = "1.18.0", repo_name = "build_bazel_rules_swift")
+bazel_dep(name = "rules_apple", version = "3.5.1", repo_name = "build_bazel_rules_apple")
+bazel_dep(name = "rules_ios", version = "4.3.1", repo_name = "build_bazel_rules_ios")

--- a/ios/BUILD
+++ b/ios/BUILD
@@ -1,0 +1,12 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+exports_files(["defs.bzl"])
+
+bzl_library(
+    name = "defs",
+    srcs = ["defs.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//ios/private:common_utils",
+    ],
+)

--- a/ios/defs.bzl
+++ b/ios/defs.bzl
@@ -2,8 +2,7 @@
 Public API for Common iOS utils
 """
 
-load("//ios/private:common_utils.bzl", _assemble_pod = "assemble_pod")
-load("//ios/private:common_utils.bzl", _ios_pipeline = "ios_pipeline")
+load("//ios/private:common_utils.bzl", _assemble_pod = "assemble_pod", _ios_pipeline = "ios_pipeline")
 
 #export Rule Dependencies here so Player does not need to load dependencies, does not work for rules_ios and rules_apple
 load("@build_bazel_rules_swift//swift:swift.bzl", _swift_library = "swift_library")

--- a/ios/defs.bzl
+++ b/ios/defs.bzl
@@ -1,0 +1,14 @@
+"""
+Public API for Common iOS utils
+"""
+
+load("//ios/private:common_utils.bzl", _assemble_pod = "assemble_pod")
+load("//ios/private:common_utils.bzl", _ios_pipeline = "ios_pipeline")
+
+#export Rule Dependencies here so Player does not need to load dependencies, does not work for rules_ios and rules_apple
+load("@build_bazel_rules_swift//swift:swift.bzl", _swift_library = "swift_library")
+
+assemble_pod = _assemble_pod
+ios_pipeline = _ios_pipeline
+
+swift_library = _swift_library

--- a/ios/private/BUILD
+++ b/ios/private/BUILD
@@ -1,0 +1,14 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "common_utils",
+    srcs = ["common_utils.bzl"],
+    visibility = [
+        "//ios:__subpackages__",
+    ],
+)
+
+exports_files([
+    "ResourceShimTemplate.swift",
+    "Info.plist"
+])

--- a/ios/private/Info.plist
+++ b/ios/private/Info.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>CFBundleIdentifier</key>
+        <string>com.intuit.ios.player.ReferenceAssets</string>
+        <key>CFBundleInfoDictionaryVersion</key>
+        <string>6.0</string>
+        <key>CFBundleName</key>
+        <string>ReferenceAssets</string>
+        <key>CFBundlePackageType</key>
+        <string>BNDL</string>
+        <key>CFBundleSignature</key>
+        <string>????</string>
+        <key>CFBundleVersion</key>
+        <string>1</string>
+        <key>DTCompiler</key>
+        <string>com.apple.compilers.llvm.clang.1_0</string>
+        <key>DTPlatformBuild</key>
+        <string>20E238</string>
+        <key>DTPlatformName</key>
+        <string>iphonesimulator</string>
+        <key>DTPlatformVersion</key>
+        <string>16.4</string>
+        <key>DTSDKBuild</key>
+        <string>20E238</string>
+        <key>DTSDKName</key>
+        <string>iphonesimulator16.4</string>
+        <key>DTXcode</key>
+        <string>1431</string>
+        <key>DTXcodeBuild</key>
+        <string>14E300c</string>
+        <key>MinimumOSVersion</key>
+        <string>13.0</string>
+        <key>UIDeviceFamily</key>
+        <array>
+                <integer>1</integer>
+                <integer>2</integer>
+        </array>
+</dict>
+</plist>

--- a/ios/private/ResourceShimTemplate.swift
+++ b/ios/private/ResourceShimTemplate.swift
@@ -1,0 +1,32 @@
+#if BAZEL_TARGET
+import Foundation
+
+private class BundleFinder {}
+
+extension Foundation.Bundle {
+    /// Returns the resource bundle associated with the current Swift module.
+    static let module: Bundle = {
+        let bundleName = "PLACEHOLDER"
+
+        let candidates: [URL?] = [
+            // Bundle should be present here when the package is linked into an App.
+            Bundle.main.resourceURL,
+
+            // Bundle should be present here when the package is linked into a framework.
+            Bundle(for: BundleFinder.self).resourceURL,
+
+            // For command-line tools.
+            Bundle.main.bundleURL,
+        ]
+
+        for candidate in candidates {
+            let bundlePath = candidate?.appendingPathComponent(bundleName + ".bundle")
+            if let bundle = bundlePath.flatMap(Bundle.init(url:)) {
+                return bundle
+            }
+        }
+
+        fatalError("unable to find bundle named \(bundleName)")
+    }()
+}
+#endif

--- a/ios/private/common_utils.bzl
+++ b/ios/private/common_utils.bzl
@@ -158,6 +158,7 @@ def ios_pipeline(
     srcs = [":" + name + "_Sources"] + ["//:.swiftlint.yml"],
     outs = ["output.sh"],
     executable = True,
+    testonly = True,
     visibility = ["//visibility:public"],
     cmd="""
       echo `$(location @SwiftLint//:swiftlint) --config $(location //:.swiftlint.yml) $(SRCS) || true` > lint_results.txt

--- a/ios/private/common_utils.bzl
+++ b/ios/private/common_utils.bzl
@@ -1,0 +1,172 @@
+load("@rules_pkg//:pkg.bzl", "pkg_zip")
+load("@rules_pkg//:mappings.bzl", "pkg_files", "strip_prefix")
+load("@build_bazel_rules_apple//apple:resources.bzl", "apple_resource_bundle")
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+load("@build_bazel_rules_ios//rules:test.bzl", "ios_unit_test", "ios_ui_test")
+
+def ios_bundle_module_shim(name):
+    native.genrule(
+        name = name + "ResourceShim",
+        srcs = ["@rules_player//ios/private:ResourceShimTemplate.swift"],
+        outs = [name + "ResourceShim.swift"],
+        cmd = "sed 's/PLACEHOLDER/" + name + "/g' < $< > $@"
+    )
+
+
+def assemble_pod(
+  name,
+  podspec = '',
+  srcs = [],
+  data = {}
+):
+  pkg_files(
+    name = "podspec",
+    srcs = [podspec],
+    strip_prefix = strip_prefix.from_pkg(),
+  )
+
+  pkg_files(
+    name = "srcs",
+    srcs = srcs,
+    strip_prefix = strip_prefix.from_pkg(),
+  )
+
+  data_pkgs = []
+  for target in data:
+    ident = "data_%d" % len(data_pkgs)
+    pkg_files(
+      name = ident,
+      srcs = [target],
+      strip_prefix = strip_prefix.from_pkg(),
+      prefix = data[target]
+    )
+    data_pkgs.append(ident)
+
+  pkg_zip(
+      name = name,
+      srcs = ["podspec", "srcs"] + data_pkgs
+  )
+
+def ios_pipeline(
+  name,
+  resources,
+  deps,
+  test_deps,
+  hasUnitTests,
+  hasViewInspectorTests,
+  test_host,
+  needsXCTest = False,
+  bundle_name = None,
+  
+):
+  """Packages source files, creates swift library and tests for a swift PlayerUI plugin
+
+  Args:
+    name: The base name of this package
+      Targets created by this macro prefix the name with 'PlayerUI'
+    resources: Any resources to include in a resource bundle
+      This will create a Bundle.module shim as well automatically
+    deps: Dependencies for the plugin
+    test_deps: Dependencies for the tests of this plugin
+    hasUnitTests: Whether or not to generate ios_unit_test tests
+    hasUITests: Whether or not to generate ios_ui_test tests
+    needsXCTest: set the 'testonly' attribute on swift_library
+    bundle_name: optionally override the name used for the resource bundle
+  """
+
+  # if we are backed by a JS package, these attributes
+  # will be populated to add to the sources/resources of the
+  # swift_library
+  data = []
+  resourceSources = []
+
+  bundleName = bundle_name if bundle_name != None else name
+
+  if len(resources) > 0:
+    apple_resource_bundle(
+      name = name + "ResourceBundle",
+      bundle_name = bundleName,
+      bundle_id = "com.intuit.ios.player.resources."+name,
+      resources = resources,
+    )
+
+    ios_bundle_module_shim(bundleName)
+    data.append(":" + name + "ResourceBundle")
+    resourceSources.append(":" + bundleName + "ResourceShim")
+
+  # Group up files to be used in swift_library
+  # and in //:PlayerUI_Pod which builds the zip of sources
+  pkg_files(
+    name = name + "_Sources",
+    srcs = native.glob(["Sources/**/*.swift"]),
+    strip_prefix = strip_prefix.from_pkg(),
+    visibility = ["//visibility:public"],
+  )
+
+  swift_library(
+      name = name,
+      module_name = name,
+      srcs = [":" + name + "_Sources"] + resourceSources,
+      visibility = ["//visibility:public"],
+      testonly = needsXCTest,
+      deps = deps,
+      data = data,
+      # this define makes Bundle.module extension work from ios_bundle_module_shim
+      defines = ["BAZEL_TARGET"]
+  )
+
+  # Packages not specific to SwiftUI don't need ViewInspector
+  # so it can just be regular unit tests
+  if hasUnitTests == True:
+    ios_unit_test(
+        name = name + "Tests",
+        srcs = native.glob(["Tests/**/*.swift"]),
+        minimum_os_version = "14.0",
+        deps = [
+          ":" + name
+        ] + deps + test_deps,
+        visibility = ["//visibility:public"]
+    )
+  # ViewInspector has to run as a UI Test to work properly
+  # SwiftUI plugins need ViewInspector
+  if hasViewInspectorTests == True:
+    ios_ui_test(
+        name = name + "ViewInspectorTests",
+        srcs = native.glob(["ViewInspector/**/*.swift"]),
+        minimum_os_version = "14.0",
+        deps = [
+            "@swiftpkg_viewinspector//:Sources_ViewInspector",
+            ":" + name
+        ] + deps + test_deps,
+        visibility = ["//visibility:public"],
+        test_host = test_host
+    )
+    
+  # Runs SwiftLint as a test calling the genrule target which outputs the result of linting
+  native.sh_test(
+    name = name + "SwiftLint",
+    srcs = [":"+ name + "_Lint"],
+    visibility = ["//visibility:public"],
+  )
+
+  # Runs the SwiftLint as part of the build, if lint fails with serious violations defer the results for the test
+  native.genrule(
+    name = name + "_Lint",
+    tools = [
+      "@SwiftLint//:swiftlint"
+    ],
+    srcs = [":" + name + "_Sources"] + ["//:.swiftlint.yml"],
+    outs = ["output.sh"],
+    executable = True,
+    visibility = ["//visibility:public"],
+    cmd="""
+      echo `$(location @SwiftLint//:swiftlint) --config $(location //:.swiftlint.yml) $(SRCS) || true` > lint_results.txt
+      LINT=$$(cat lint_results.txt)
+
+      echo '#!/bin/bash' > $(location output.sh)
+      echo "echo '$$LINT'" > $(location output.sh)
+
+      LINESWITHERROR=$$(echo grep error lint_results.txt || true)
+      echo "exit $$(($$LINESWITHERROR) | wc -l)" >> $(location output.sh)
+  """
+  )


### PR DESCRIPTION
move macros `assemble_pod` and `ios_pipeline` to common place to be reused in playerplugins

Player repo can load `swift_library` through rules_player since its used in here as well so no need to have dependency in two places, but doesnt work for rules_apple and rules_ios (need a different way to deal with duplicates later)
