### PR TITLE
iOS_pipeline macro seperate out uitests

### DIFF
--- a/ios/private/common_utils.bzl
+++ b/ios/private/common_utils.bzl
@@ -70,8 +70,10 @@ def ios_pipeline(
     deps: Dependencies for the plugin
     test_deps: Dependencies for the tests of this plugin
     hasUnitTests: Whether or not to generate ios_unit_test tests
-    hasUITests: Whether or not to generate ios_ui_test tests
+    
     hasViewInspectorTests: Whether or not to generate ios_ui_test tests that require ViewInspector
+    test_host: the target where the tests should run (Demo app target)
+    hasUITests: Whether or not to generate ios_ui_test tests
     needsXCTest: set the 'testonly' attribute on swift_library
     bundle_name: optionally override the name used for the resource bundle
   """

--- a/ios/private/common_utils.bzl
+++ b/ios/private/common_utils.bzl
@@ -55,6 +55,7 @@ def ios_pipeline(
   hasUnitTests,
   hasViewInspectorTests,
   test_host,
+  hasUITests = False,
   needsXCTest = False,
   bundle_name = None,
   
@@ -70,6 +71,7 @@ def ios_pipeline(
     test_deps: Dependencies for the tests of this plugin
     hasUnitTests: Whether or not to generate ios_unit_test tests
     hasUITests: Whether or not to generate ios_ui_test tests
+    hasViewInspectorTests: Whether or not to generate ios_ui_test tests that require ViewInspector
     needsXCTest: set the 'testonly' attribute on swift_library
     bundle_name: optionally override the name used for the resource bundle
   """
@@ -128,7 +130,7 @@ def ios_pipeline(
         visibility = ["//visibility:public"]
     )
   # ViewInspector has to run as a UI Test to work properly
-  # SwiftUI plugins need ViewInspector
+  # Some SwiftUI plugins need ViewInspector
   if hasViewInspectorTests == True:
     ios_ui_test(
         name = name + "ViewInspectorTests",
@@ -137,6 +139,18 @@ def ios_pipeline(
         deps = [
             "@swiftpkg_viewinspector//:Sources_ViewInspector",
             ":" + name
+        ] + deps + test_deps,
+        visibility = ["//visibility:public"],
+        test_host = test_host
+    )
+
+  #Some SwiftUI plugins have UI tests without ViewInspector
+  if hasUITests == True:
+    ios_ui_test(
+        name = name + "UITests",
+        srcs = native.glob(["UITests/**/*.swift"]),
+        minimum_os_version = "14.0",
+         deps = [
         ] + deps + test_deps,
         visibility = ["//visibility:public"],
         test_host = test_host

--- a/ios/private/common_utils.bzl
+++ b/ios/private/common_utils.bzl
@@ -69,13 +69,12 @@ def ios_pipeline(
       This will create a Bundle.module shim as well automatically
     deps: Dependencies for the plugin
     test_deps: Dependencies for the tests of this plugin
-    hasUnitTests: Whether or not to generate ios_unit_test tests
-    
+    hasUnitTests: Whether or not to generate ios_unit_test tests  
     hasViewInspectorTests: Whether or not to generate ios_ui_test tests that require ViewInspector
-    test_host: the target where the tests should run (Demo app target)
+    test_host: The target where the tests should run (Demo app target)
     hasUITests: Whether or not to generate ios_ui_test tests
-    needsXCTest: set the 'testonly' attribute on swift_library
-    bundle_name: optionally override the name used for the resource bundle
+    needsXCTest: Set the 'testonly' attribute on swift_library
+    bundle_name: Pptionally override the name used for the resource bundle
   """
 
   # if we are backed by a JS package, these attributes


### PR DESCRIPTION
* use ui test target for ui tests not using viewinspector
* requires ui test sources to be under UITest folder