### PR TITLE
Gitignore - ghpage.js update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@
 /.settings
 /.vscode/
 /bazel.iml
+
+# Ignore generated file from gh-page.
+/gh-pages/private/gh_pages.js
+
 # Ignore all bazel-* symlinks. There is no full list since this can change
 # based on the name of the directory bazel is cloned into.
 **/bazel-*


### PR DESCRIPTION
`yarn auto shipit -vv `

was failing due to the generated .js file. added the file to git ignore 