### PR TITLE
Fix stamp_tar_files 

### DIFF
--- a/distribution/tar/private/stamp_tar_files.bzl
+++ b/distribution/tar/private/stamp_tar_files.bzl
@@ -33,9 +33,6 @@ def stamp_tar_impl(ctx):
 
     if stamp:
         input = [ctx.info_file]
-        args["info_file"] = stamp.stable_status_file.path
-        args["version_file"] = stamp.volatile_status_file.path
-        args["stamped_tar_path"] = ctx.info_file.path
 
     ctx.actions.run(
         inputs = ctx.files.tar + input,

--- a/distribution/tar/private/stamp_tar_files.mjs
+++ b/distribution/tar/private/stamp_tar_files.mjs
@@ -43,15 +43,10 @@ const repackageTar = async (input_file, output_file, substitutions) => {
   spawnSync('tar',['-czvf', output_file, '-C', tempOutputDir, '.'], {stdio:'inherit'})
 }
 
-const removePaths = (filePath) =>{
-  const pathToRemove = '/bazel-out/darwin_arm64-fastbuild/bin';
-  return filePath.replace(pathToRemove, "")
-}
-const main = async ([config]) => {
-  const { input_file, version_file, output_file, stamp, stable, substitutions,stamped_tar_path } = JSON.parse(config);
 
-  const file = stable ? info_file : version_file 
-  
+const main = async ([config]) => {
+  const { input_file, output_file, stamp, substitutions } = JSON.parse(config);
+
   const resolvedInputFile = path.resolve(input_file)
   const resolvedOutputFile = path.resolve(output_file)
 
@@ -61,8 +56,7 @@ const main = async ([config]) => {
     return;
   }
   
-  // get the absolute path of the stamp path
-  const stampFilePath = removePaths(path.resolve(stamped_tar_path))
+  const stampFilePath = path.resolve(input_file)
 
   const stampFile = fs.readFileSync(stampFilePath,"utf-8");
 

--- a/gh-pages/private/gh-pages.js
+++ b/gh-pages/private/gh-pages.js
@@ -1,4 +1,3 @@
-"use strict";
 var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;


### PR DESCRIPTION
On prod;

the stamped_tar_path was evaluating to `bazel-out/stable-status.txt`
This was causing  the stamp file path to not be a stamp.

tested with
```shell
STABLE_DOCS_BASE_PATH=next bazel run --verbose_failures --config=release //docs:gh_deploy -- --dest_dir next

STABLE_DOCS_BASE_PATH=$SEMVER_MAJOR bazel run --verbose_failures --config=release //docs:gh_deploy -- --dest_dir "$SEMVER_MAJOR"

STABLE_DOCS_BASE_PATH=latest bazel run --verbose_failures --config=release //docs:gh_deploy -- --dest_dir latest

bazel build //docs:gh_deploy

bazel build //docs:full_site_stamped
``` 
