### PR TITLE
Stamping Fix - Calls the right stamp file

### DIFF
--- a/distribution/tar/private/stamp_tar_files.bzl
+++ b/distribution/tar/private/stamp_tar_files.bzl
@@ -23,22 +23,21 @@ def stamp_tar_impl(ctx):
     inputs = []
 
     stamped_tar = ctx.actions.declare_file(paths.basename(ctx.attr.name + ".tar.gz"))
-    
+
     stamp = maybe_stamp(ctx)
 
     args = {
         "input_file": ctx.file.tar.short_path,
         "output_file": stamped_tar.short_path,
+        "stable": ctx.attr.stable,
         "stamp": ctx.info_file.path if stamp else None,
         "substitutions": ctx.attr.substitutions,
-        "stable": ctx.attr.stable,
     }
 
     if stamp:
         inputs = [stamp.volatile_status_file, stamp.stable_status_file]
         args["info_file"] = stamp.stable_status_file.path
         args["version_file"] = stamp.volatile_status_file.path
-
 
     ctx.actions.run(
         inputs = inputs + ctx.files.tar,
@@ -60,12 +59,12 @@ def stamp_tar_impl(ctx):
 stamp_tar_files = rule(
     implementation = stamp_tar_impl,
     attrs = dict({
-        "substitutions": attr.string_dict(
-            doc = "A mapping of values to replace in a file, to the stamp variables",
-        ),
         "stable": attr.bool(
             default = False,
             doc = "If true, replaces variables from stable-status. False replaces from volatile-status",
+        ),
+        "substitutions": attr.string_dict(
+            doc = "A mapping of values to replace in a file, to the stamp variables",
         ),
         "tar": attr.label(
             allow_single_file = True,

--- a/distribution/tar/private/stamp_tar_files.bzl
+++ b/distribution/tar/private/stamp_tar_files.bzl
@@ -36,8 +36,8 @@ def stamp_tar_impl(ctx):
 
     if stamp:
         inputs = [stamp.volatile_status_file, stamp.stable_status_file]
-        args["info_file"] = stamp.stable_status_file.path
-        args["version_file"] = stamp.volatile_status_file.path
+        args["stable_file"] = stamp.stable_status_file.path
+        args["volatile_file"] = stamp.volatile_status_file.path
 
     ctx.actions.run(
         inputs = inputs + ctx.files.tar,

--- a/distribution/tar/private/stamp_tar_files.mjs
+++ b/distribution/tar/private/stamp_tar_files.mjs
@@ -45,20 +45,24 @@ const repackageTar = async (input_file, output_file, substitutions) => {
 
 
 const main = async ([config]) => {
-  const { input_file, output_file, stamp, substitutions } = JSON.parse(config);
+  const { input_file, output_file,stable, stamp, substitutions,version_file, info_file} = JSON.parse(config);
 
   const resolvedInputFile = path.resolve(input_file)
   const resolvedOutputFile = path.resolve(output_file)
 
-  // Don't do much if we don't have to stamp, just copy it over as is
+  // If stamping doesnt exist, just copy files
   if (!stamp) {
     fs.copyFileSync(resolvedInputFile, resolvedOutputFile);
     return;
   }
   
-  const stampFilePath = path.resolve(input_file)
+  // from bazel builld //docs:gh_deploy no info and version file
+  let file = stable ? info_file : version_file 
 
-  const stampFile = fs.readFileSync(stampFilePath,"utf-8");
+  // need this to find the bazel-out/ path
+  process.chdir(process.env.JS_BINARY__EXECROOT)  
+
+  const stampFile = fs.readFileSync(file,"utf-8");
 
   // TODO: Should share this as a common module
   stampFile.split("\n").forEach((line) => {
@@ -79,8 +83,6 @@ const main = async ([config]) => {
       }
     });
   });
-
-
 
   await repackageTar(resolvedInputFile, resolvedOutputFile, substitutions);
 

--- a/distribution/tar/private/stamp_tar_files.mjs
+++ b/distribution/tar/private/stamp_tar_files.mjs
@@ -20,6 +20,7 @@ async function handleSubstitutions(folderOrFile, substitutions) {
   }
 
   let contents = await fs.promises.readFile(folderOrFile, "utf-8");
+
   const originalContents = contents;
   for (const key in substitutions) {
     const value = substitutions[key];
@@ -29,6 +30,7 @@ async function handleSubstitutions(folderOrFile, substitutions) {
   if (contents !== originalContents) {
     await fs.promises.writeFile(folderOrFile, contents);
   }
+
 }
 
 const repackageTar = async (input_file, output_file, substitutions) => {
@@ -40,12 +42,13 @@ const repackageTar = async (input_file, output_file, substitutions) => {
 
   await handleSubstitutions(tempOutputDir, substitutions);
 
+ 
   spawnSync('tar',['-czvf', output_file, '-C', tempOutputDir, '.'], {stdio:'inherit'})
 }
 
 
 const main = async ([config]) => {
-  const { input_file, output_file,stable, stamp, substitutions,version_file, info_file} = JSON.parse(config);
+  const { input_file, output_file,stable, stamp, substitutions,volatile_file, stable_file} = JSON.parse(config);
 
   const resolvedInputFile = path.resolve(input_file)
   const resolvedOutputFile = path.resolve(output_file)
@@ -56,8 +59,7 @@ const main = async ([config]) => {
     return;
   }
   
-  // from bazel builld //docs:gh_deploy no info and version file
-  let file = stable ? info_file : version_file 
+  let file = stable ? stable_file : volatile_file 
 
   // need this to find the bazel-out/ path
   process.chdir(process.env.JS_BINARY__EXECROOT)  


### PR DESCRIPTION
Previously, the stampfile was trying to read the tar file. Which caused it to pass but make no substitutions 

```javascript
  stampFile.split("\n").forEach((line) => {
    const firstSpace = line.indexOf(" ");
    const varName = line.substring(0, firstSpace);
    let varVal = line.substring(firstSpace + 1);

    // Using the same match as https://github.com/bazelbuild/rules_nodejs/blob/stable/internal/pkg_npm/packager.js#L139
    if (varName.endsWith('_VERSION')) {
      // vscode doesn't let you have `-canary` suffixes
      varVal = varVal.replace(/[^\d.]/g, '');
    }

    // Swap out anything referencing the stamped file with the actual value
    Object.keys(substitutions).forEach((key) => {
      if (substitutions[key] === `{${varName}}`) {
        substitutions[key] = varVal;
      }
    });
  });
``` 

Previously, did not have  `process.chdir(process.env.JS_BINARY__EXECROOT)`  , which made it so these files could not be found while after maybe_stamp() was called.

After adding in `process.chdir(process.env.JS_BINARY__EXECROOT)`, it is now able to process the correct stamping file.


