### PR TITLE
Collect Source Maps During DSL compilation

### DIFF
--- a/docs/player.md
+++ b/docs/player.md
@@ -27,7 +27,8 @@ create_base_config(<a href="#create_base_config-name">name</a>, <a href="#create
 ## compile
 
 <pre>
-compile(<a href="#compile-name">name</a>, <a href="#compile-node_modules">node_modules</a>, <a href="#compile-srcs">srcs</a>, <a href="#compile-input_dir">input_dir</a>, <a href="#compile-output_dir">output_dir</a>, <a href="#compile-data">data</a>, <a href="#compile-config">config</a>, <a href="#compile-skip_test">skip_test</a>, <a href="#compile-kwargs">kwargs</a>)
+compile(<a href="#compile-name">name</a>, <a href="#compile-node_modules">node_modules</a>, <a href="#compile-srcs">srcs</a>, <a href="#compile-input_dir">input_dir</a>, <a href="#compile-output_dir">output_dir</a>, <a href="#compile-data">data</a>, <a href="#compile-config">config</a>, <a href="#compile-skip_test">skip_test</a>, <a href="#compile-schema_name">schema_name</a>,
+        <a href="#compile-kwargs">kwargs</a>)
 </pre>
 
 Run the src or src_dir through the player compiler.
@@ -45,6 +46,7 @@ Run the src or src_dir through the player compiler.
 | <a id="compile-data"></a>data |  Additional data to pass to the compiler   |  `[]` |
 | <a id="compile-config"></a>config |  A config override to use   |  `None` |
 | <a id="compile-skip_test"></a>skip_test |  Flag to skip generating the *_test target   |  `False` |
+| <a id="compile-schema_name"></a>schema_name |  Name of the file containing the schema, defaults to "schema.ts"   |  `"schema.ts"` |
 | <a id="compile-kwargs"></a>kwargs |  Additonal args to pass to the js_run_binary cmd   |  none |
 
 
@@ -53,7 +55,8 @@ Run the src or src_dir through the player compiler.
 ## dsl_compile
 
 <pre>
-dsl_compile(<a href="#dsl_compile-name">name</a>, <a href="#dsl_compile-node_modules">node_modules</a>, <a href="#dsl_compile-srcs">srcs</a>, <a href="#dsl_compile-input_dir">input_dir</a>, <a href="#dsl_compile-output_dir">output_dir</a>, <a href="#dsl_compile-data">data</a>, <a href="#dsl_compile-config">config</a>, <a href="#dsl_compile-skip_test">skip_test</a>, <a href="#dsl_compile-kwargs">kwargs</a>)
+dsl_compile(<a href="#dsl_compile-name">name</a>, <a href="#dsl_compile-node_modules">node_modules</a>, <a href="#dsl_compile-srcs">srcs</a>, <a href="#dsl_compile-input_dir">input_dir</a>, <a href="#dsl_compile-output_dir">output_dir</a>, <a href="#dsl_compile-data">data</a>, <a href="#dsl_compile-config">config</a>, <a href="#dsl_compile-skip_test">skip_test</a>, <a href="#dsl_compile-schema_name">schema_name</a>,
+            <a href="#dsl_compile-kwargs">kwargs</a>)
 </pre>
 
 Run the src or src_dir through the player compiler.
@@ -71,6 +74,7 @@ Run the src or src_dir through the player compiler.
 | <a id="dsl_compile-data"></a>data |  Additional data to pass to the compiler   |  `[]` |
 | <a id="dsl_compile-config"></a>config |  A config override to use   |  `None` |
 | <a id="dsl_compile-skip_test"></a>skip_test |  Flag to skip generating the *_test target   |  `False` |
+| <a id="dsl_compile-schema_name"></a>schema_name |  Name of the file containing the schema, defaults to "schema.ts"   |  `"schema.ts"` |
 | <a id="dsl_compile-kwargs"></a>kwargs |  Additonal args to pass to the js_run_binary cmd   |  none |
 
 

--- a/player/private/dsl.bzl
+++ b/player/private/dsl.bzl
@@ -42,10 +42,9 @@ def compile(name, node_modules = "//:node_modules", srcs = None, input_dir = "sr
     output_dir = output_dir if output_dir else "{}_dist".format(name)
     outputs = []
     for src in srcs:
-        outputs += [paths.join(output_dir, paths.relativize(paths.replace_extension(src, ".json"), input_dir))]
-        if(schema_name not in src):
-            outputs += [paths.join(output_dir, paths.relativize(paths.replace_extension(src, ".json.map"), input_dir))]
-
+        outputs.append(paths.join(output_dir, paths.relativize(paths.replace_extension(src, ".json"), input_dir)))
+        if (schema_name not in src):
+            outputs.append(paths.join(output_dir, paths.relativize(paths.replace_extension(src, ".json.map"), input_dir)))
 
     js_run_binary(
         name = name,

--- a/player/private/dsl.bzl
+++ b/player/private/dsl.bzl
@@ -6,7 +6,7 @@ load("@aspect_bazel_lib//lib:directory_path.bzl", "directory_path")
 load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_run_binary", "js_test")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 
-def compile(name, node_modules = "//:node_modules", srcs = None, input_dir = "src", output_dir = None, data = [], config = None, skip_test = False, **kwargs):
+def compile(name, node_modules = "//:node_modules", srcs = None, input_dir = "src", output_dir = None, data = [], config = None, skip_test = False, schema_name = "schema.ts", **kwargs):
     """Run the src or src_dir through the player compiler.
 
     Args:
@@ -18,6 +18,7 @@ def compile(name, node_modules = "//:node_modules", srcs = None, input_dir = "sr
         data: Additional data to pass to the compiler
         config: A config override to use
         skip_test: Flag to skip generating the *_test target
+        schema_name: Name of the file containing the schema, defaults to "schema.ts"
         **kwargs: Additonal args to pass to the js_run_binary cmd
     """
 
@@ -39,7 +40,12 @@ def compile(name, node_modules = "//:node_modules", srcs = None, input_dir = "sr
     )
 
     output_dir = output_dir if output_dir else "{}_dist".format(name)
-    outputs = [paths.join(output_dir, paths.relativize(paths.replace_extension(src, ".json"), input_dir)) for src in srcs]
+    outputs = []
+    for src in srcs:
+        outputs += [paths.join(output_dir, paths.relativize(paths.replace_extension(src, ".json"), input_dir))]
+        if(schema_name not in src):
+            outputs += [paths.join(output_dir, paths.relativize(paths.replace_extension(src, ".json.map"), input_dir))]
+
 
     js_run_binary(
         name = name,


### PR DESCRIPTION
One thing to note is that since the schema doesn't produce a map file when compiled, its name needs to be known in order to not expect it's map file. Taking it an an optional arg with the default being our recommended `schema.ts` seemed reasonable to me but am open to other ideas. 

## Release Notes
Collect source maps as outputs from DSL compilation rule