### PR TITLE
Add Android resources when publishing `kt_android` artifacts 

### DIFF
--- a/kotlin/private/kt_android_library_and_test.bzl
+++ b/kotlin/private/kt_android_library_and_test.bzl
@@ -81,6 +81,8 @@ def kt_android_library_and_test(
     android_library(
         name = name,
         manifest = manifest,
+        resource_files = main_res,
+        assets = main_assets,
         tags = tags,
         exports = [":%s" % base_name] + main_exports,
         deps = main_deps,


### PR DESCRIPTION
Building AARs to publish apparently don't take into account transitive android resource closures — this change manually propagates the relevant Android resources to publish, but could eventually be fixed upstream by ensuring that Android resources defined in transitive `android_library`s  are accounted for when building the published artifact.

# Release Notes

Propagate Android resources to published `kt_android` artifacts