### PR TITLE
Add support for README.md files in JS Macros

### DIFF
--- a/javascript/private/js_pipeline.bzl
+++ b/javascript/private/js_pipeline.bzl
@@ -184,11 +184,13 @@ def js_pipeline(
     replacements[package_json_name] = "package"
     replacements[ts_types + "/src"] = "types"
 
+    readme_files = native.glob(["README.md"], allow_empty = True)
+
     npm_package(
         name = name,
         visibility = ["//visibility:public"],
         package = package_name,
-        srcs = [js_library_target, tsup_build_target] + include_packaging_targets,
+        srcs = [js_library_target, tsup_build_target] + readme_files + include_packaging_targets,
         tags = filter_empty([
             "do-not-publish" if private else None,
         ]),

--- a/javascript/private/oclif.bzl
+++ b/javascript/private/oclif.bzl
@@ -170,10 +170,11 @@ def oclif_pipeline(
     package_name = name
     package_target = ":" + package_name
 
+    readme_files = native.glob(["README.md"], allow_empty = True)
+
     npm_package(
         name = package_name,
-        srcs = [
-            "README.md",
+        srcs = readme_files + [
             bundle_target,
         ],
         allow_overwrites = True,


### PR DESCRIPTION
## Release Notes
Include README.md file if present for `js_pipeline` and `oclif_pipeline` macros