### PR TITLE
Add a `SwiftLint_FIx` target

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -67,3 +67,11 @@ bazel_dep(name = "zlib", version = "1.3.1")
 bazel_dep(name = "bazel_bats", version = "0.35.0")
 
 bazel_dep(name = "rules_python", version = "1.6.1")
+
+## iOS Formatting
+bazel_dep(name = "rules_swift_tidy", version = "0.0.0")
+git_override(
+    module_name = "rules_swift_tidy",
+    commit = "751202ff4e97afc6a749ab15de502a2a0b1ac401",
+    remote = "https://github.com/cgrindel/rules_swiftformat.git",
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -69,9 +69,10 @@ bazel_dep(name = "bazel_bats", version = "0.35.0")
 bazel_dep(name = "rules_python", version = "1.6.1")
 
 ## iOS Formatting
-bazel_dep(name = "rules_swift_tidy", version = "0.0.0")
-git_override(
+bazel_dep(name = "rules_swift_tidy")
+archive_override(
     module_name = "rules_swift_tidy",
-    commit = "751202ff4e97afc6a749ab15de502a2a0b1ac401",
-    remote = "https://github.com/cgrindel/rules_swiftformat.git",
+    urls = ["https://github.com/cgrindel/rules_swiftformat/archive/v0.4.1.tar.gz"],
+    strip_prefix = "rules_swiftformat-0.4.1",
+    integrity = "sha256-9JZ3T1boJg4nfcFzZs9nC1Xe42FjJ6E9LQS9G2LNzIg=",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -55,7 +55,7 @@ use_repo(maven, "rules_player_maven")
 bazel_dep(name = "rules_android", version = "0.6.5")
 
 ## Rule Dependencies
-bazel_dep(name = "rules_swift", version = "3.4.1", repo_name = "build_bazel_rules_swift")
+bazel_dep(name = "rules_swift", version = "2.9.0", repo_name = "build_bazel_rules_swift")
 bazel_dep(name = "rules_apple", version = "4.3.3", repo_name = "build_bazel_rules_apple")
 
 bazel_dep(name = "rules_bazel_integration_test", version = "0.24.1", dev_dependency = True)

--- a/ios/private/common_utils.bzl
+++ b/ios/private/common_utils.bzl
@@ -185,3 +185,33 @@ def ios_pipeline(
       echo "exit $$(($$LINESWITHERROR) | wc -l)" >> $(location output.sh)
   """,
     )
+
+    # Runs SwiftLint with autofix as a test calling the genrule target which outputs the result of linting
+    native.sh_test(
+        name = name + "SwiftLint_Fix",
+        srcs = [":" + name + "_LintFix"],
+        visibility = ["//visibility:public"],
+    )
+
+    # Runs SwiftLint with autofix as part of the build, if lint fails with serious violations defer the results for the test
+    native.genrule(
+        name = name + "_LintFix",
+        tools = [
+            "@SwiftLint//:swiftlint",
+        ],
+        srcs = [":" + name + "_Sources"] + ["//:.swiftlint.yml"],
+        outs = ["output_fix.sh"],
+        executable = True,
+        testonly = True,
+        visibility = ["//visibility:private"],
+        cmd = """
+      echo `$(location @SwiftLint//:swiftlint) --fix --config $(location //:.swiftlint.yml) $(SRCS) || true` > lint_results.txt
+      LINT=$$(cat lint_results.txt)
+
+      echo '#!/bin/bash' > $(location output_fix.sh)
+      echo "echo '$$LINT'" > $(location output_fix.sh)
+
+      LINESWITHERROR=$$(echo grep error lint_results.txt || true)
+      echo "exit $$(($$LINESWITHERROR) | wc -l)" >> $(location output_fix.sh)
+  """,
+    )

--- a/ios/private/common_utils.bzl
+++ b/ios/private/common_utils.bzl
@@ -6,6 +6,7 @@ load("@build_bazel_rules_apple//apple:ios.bzl", "ios_ui_test", "ios_unit_test")
 load("@build_bazel_rules_apple//apple:resources.bzl", "apple_resource_bundle")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 load("@rules_pkg//:mappings.bzl", "pkg_files", "strip_prefix")
+load("@rules_swift_tidy//swiftformat:defs.bzl", "swiftformat_pkg")
 
 def ios_bundle_module_shim(name):
     native.genrule(
@@ -214,4 +215,12 @@ def ios_pipeline(
       LINESWITHERROR=$$(echo grep error lint_results.txt || true)
       echo "exit $$(($$LINESWITHERROR) | wc -l)" >> $(location output_fix.sh)
   """,
+    )
+
+    # Runs SwiftFormat lint check per target (fails if files would change)
+    # and generates a .update target to apply formatting fixes
+    swiftformat_pkg(
+        name = name + "SwiftFormat",
+        srcs = [":" + name + "_Sources"],
+        config = "//:.swiftformat",
     )


### PR DESCRIPTION
We currently have a command to run SwiftLint, but not one that allows the automatic fixing. It is very inconvenient.

This PR introduces a Lint fix.