### PR TITLE
Add `features` and `minimum_os_version` parameter to `ios_pipeline`

### DIFF
--- a/docs/ios.md
+++ b/docs/ios.md
@@ -214,7 +214,7 @@ This will be removed in v3. Use `assemble_ios_release` which provides a unified 
 load("@rules_player//ios:defs.bzl", "ios_pipeline")
 
 ios_pipeline(<a href="#ios_pipeline-name">name</a>, <a href="#ios_pipeline-resources">resources</a>, <a href="#ios_pipeline-deps">deps</a>, <a href="#ios_pipeline-test_deps">test_deps</a>, <a href="#ios_pipeline-hasUnitTests">hasUnitTests</a>, <a href="#ios_pipeline-hasViewInspectorTests">hasViewInspectorTests</a>, <a href="#ios_pipeline-test_host">test_host</a>,
-             <a href="#ios_pipeline-hasUITests">hasUITests</a>, <a href="#ios_pipeline-needsXCTest">needsXCTest</a>, <a href="#ios_pipeline-bundle_name">bundle_name</a>)
+             <a href="#ios_pipeline-hasUITests">hasUITests</a>, <a href="#ios_pipeline-needsXCTest">needsXCTest</a>, <a href="#ios_pipeline-bundle_name">bundle_name</a>, <a href="#ios_pipeline-features">features</a>)
 </pre>
 
 Packages source files, creates swift library and tests for a swift PlayerUI plugin
@@ -233,6 +233,7 @@ Packages source files, creates swift library and tests for a swift PlayerUI plug
 | <a id="ios_pipeline-test_host"></a>test_host |  The target where the tests should run (Demo app target)   |  none |
 | <a id="ios_pipeline-hasUITests"></a>hasUITests |  Whether or not to generate ios_ui_test tests   |  `False` |
 | <a id="ios_pipeline-needsXCTest"></a>needsXCTest |  Set the 'testonly' attribute on swift_library   |  `False` |
-| <a id="ios_pipeline-bundle_name"></a>bundle_name |  Pptionally override the name used for the resource bundle   |  `None` |
+| <a id="ios_pipeline-bundle_name"></a>bundle_name |  Optionally override the name used for the resource bundle   |  `None` |
+| <a id="ios_pipeline-features"></a>features |  List of features to pass to the swift_library target (e.g. ["swift.enable_testing"])   |  `[]` |
 
 

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -214,7 +214,7 @@ This will be removed in v3. Use `assemble_ios_release` which provides a unified 
 load("@rules_player//ios:defs.bzl", "ios_pipeline")
 
 ios_pipeline(<a href="#ios_pipeline-name">name</a>, <a href="#ios_pipeline-resources">resources</a>, <a href="#ios_pipeline-deps">deps</a>, <a href="#ios_pipeline-test_deps">test_deps</a>, <a href="#ios_pipeline-hasUnitTests">hasUnitTests</a>, <a href="#ios_pipeline-hasViewInspectorTests">hasViewInspectorTests</a>, <a href="#ios_pipeline-test_host">test_host</a>,
-             <a href="#ios_pipeline-hasUITests">hasUITests</a>, <a href="#ios_pipeline-needsXCTest">needsXCTest</a>, <a href="#ios_pipeline-bundle_name">bundle_name</a>, <a href="#ios_pipeline-features">features</a>)
+             <a href="#ios_pipeline-hasUITests">hasUITests</a>, <a href="#ios_pipeline-needsXCTest">needsXCTest</a>, <a href="#ios_pipeline-bundle_name">bundle_name</a>, <a href="#ios_pipeline-features">features</a>, <a href="#ios_pipeline-minimum_os_version">minimum_os_version</a>)
 </pre>
 
 Packages source files, creates swift library and tests for a swift PlayerUI plugin
@@ -235,5 +235,6 @@ Packages source files, creates swift library and tests for a swift PlayerUI plug
 | <a id="ios_pipeline-needsXCTest"></a>needsXCTest |  Set the 'testonly' attribute on swift_library   |  `False` |
 | <a id="ios_pipeline-bundle_name"></a>bundle_name |  Optionally override the name used for the resource bundle   |  `None` |
 | <a id="ios_pipeline-features"></a>features |  List of features to pass to the swift_library target (e.g. ["swift.enable_testing"])   |  `[]` |
+| <a id="ios_pipeline-minimum_os_version"></a>minimum_os_version |  Minimum iOS version for test targets (default "14.0")   |  `"14.0"` |
 
 

--- a/ios/private/common_utils.bzl
+++ b/ios/private/common_utils.bzl
@@ -25,7 +25,8 @@ def ios_pipeline(
         test_host,
         hasUITests = False,
         needsXCTest = False,
-        bundle_name = None):
+        bundle_name = None,
+        features = []):
     """Packages source files, creates swift library and tests for a swift PlayerUI plugin
 
     Args:
@@ -40,7 +41,8 @@ def ios_pipeline(
       test_host: The target where the tests should run (Demo app target)
       hasUITests: Whether or not to generate ios_ui_test tests
       needsXCTest: Set the 'testonly' attribute on swift_library
-      bundle_name: Pptionally override the name used for the resource bundle
+      bundle_name: Optionally override the name used for the resource bundle
+      features: List of features to pass to the swift_library target (e.g. ["swift.enable_testing"])
     """
 
     # if we are backed by a JS package, these attributes
@@ -85,6 +87,7 @@ def ios_pipeline(
         #       should likely have a better way to dynamically configure `-DSWIFT_PACKAGE`
         #       rather than applying it holistically to every `swift_library`
         defines = ["BAZEL_TARGET", "SWIFT_PACKAGE"],
+        features = features,
     )
 
     # Packages not specific to SwiftUI don't need ViewInspector

--- a/ios/private/common_utils.bzl
+++ b/ios/private/common_utils.bzl
@@ -26,7 +26,8 @@ def ios_pipeline(
         hasUITests = False,
         needsXCTest = False,
         bundle_name = None,
-        features = []):
+        features = [],
+        minimum_os_version = "14.0"):
     """Packages source files, creates swift library and tests for a swift PlayerUI plugin
 
     Args:
@@ -43,6 +44,7 @@ def ios_pipeline(
       needsXCTest: Set the 'testonly' attribute on swift_library
       bundle_name: Optionally override the name used for the resource bundle
       features: List of features to pass to the swift_library target (e.g. ["swift.enable_testing"])
+      minimum_os_version: Minimum iOS version for test targets (default "14.0")
     """
 
     # if we are backed by a JS package, these attributes
@@ -106,7 +108,7 @@ def ios_pipeline(
         )
         ios_unit_test(
             name = unit_test_name,
-            minimum_os_version = "14.0",
+            minimum_os_version = minimum_os_version,
             deps = [
                 unit_test_library_target,
             ] + deps + test_deps,
@@ -130,7 +132,7 @@ def ios_pipeline(
         )
         ios_ui_test(
             name = viewinspector_test_name,
-            minimum_os_version = "14.0",
+            minimum_os_version = minimum_os_version,
             deps = [viewinspector_test_library_target],
             visibility = ["//visibility:public"],
             test_host = test_host,
@@ -151,7 +153,7 @@ def ios_pipeline(
         )
         ios_ui_test(
             name = ui_test_name,
-            minimum_os_version = "14.0",
+            minimum_os_version = minimum_os_version,
             deps = [
                 ui_test_library_target,
             ] + deps + test_deps,


### PR DESCRIPTION
Adds an optional `features` parameter to `ios_pipeline` (defaults to `[]`), passed through to the main `swift_library target`. This enables callers to set Swift compiler features such as `swift.enable_testing`, which compiles the module with `-enable-testing`. This allows dependent bazel modules to see internal functions, properties, etc by using `@testable import`.

Also allows callers to override the minimum iOS version for generated test targets rather than being locked to "14.0". Defaults to "14.0" for full backward compatibility.