### PR TITLE
When making the ios release, strip the branch down before unzip

### DIFF
--- a/ios/private/unzip_and_tag.sh
+++ b/ios/private/unzip_and_tag.sh
@@ -33,7 +33,10 @@ cd publishRepo
 git fetch --all
 
 # Switches to the target branch
-git checkout -b $BRANCH
+git checkout -b $BRANCH 
+
+# Delete everything except the LICENSE and .git
+find . -mindepth 1 -maxdepth 1 ! -name LICENSE ! -name .git -exec rm -rf {} +
 
 # Unzip contents and overwrite files in the target repository
 unzip -o ../{ZIP} -d .


### PR DESCRIPTION
We recently had a corrupted release go out (0.15.5) that had files from 1.0 in it when it should not have. To avoid this, change the script to strip down the release branch to almost nothing before we unzip new files. (Rather than having everything from `main`).